### PR TITLE
Feat: 소셜 로그인 서버 연동 & #0-2 유저 ID 생성 화면 구현

### DIFF
--- a/Pointer_iOS.xcodeproj/project.pbxproj
+++ b/Pointer_iOS.xcodeproj/project.pbxproj
@@ -1104,9 +1104,13 @@
 				CODE_SIGN_ENTITLEMENTS = Pointer_iOS/Pointer_iOS.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = F6SZ5LV55B;
+				DEVELOPMENT_TEAM = 2W8MRY52UN;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Pointer_iOS/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "사진 및 동영상 첨부를 위한 카메라 사용 권한";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "동영상 촬영 및 음성인식을 위한 권한 필요";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "사진 및 동영상 추가를 위한 앨범 사용 권한";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "사진 및 동영상 첨부를 위한 앨범 사용 권한";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleLightContent;
@@ -1117,7 +1121,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.Pointer.Pointer-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = com.pointerApp.iOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -1133,9 +1137,13 @@
 				CODE_SIGN_ENTITLEMENTS = Pointer_iOS/Pointer_iOS.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = F6SZ5LV55B;
+				DEVELOPMENT_TEAM = 2W8MRY52UN;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Pointer_iOS/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "사진 및 동영상 첨부를 위한 카메라 사용 권한";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "동영상 촬영 및 음성인식을 위한 권한 필요";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "사진 및 동영상 추가를 위한 앨범 사용 권한";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "사진 및 동영상 첨부를 위한 앨범 사용 권한";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleLightContent;
@@ -1146,7 +1154,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.Pointer.Pointer-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = com.pointerApp.iOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/Pointer_iOS.xcodeproj/project.pbxproj
+++ b/Pointer_iOS.xcodeproj/project.pbxproj
@@ -21,7 +21,6 @@
 		47117CE629CD92D5001707C8 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47117CE529CD92D5001707C8 /* LoginViewModel.swift */; };
 		47117CF129CD9A1C001707C8 /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 47117CF029CD9A1C001707C8 /* KakaoSDK */; };
 		47194E7D29D94DA900671360 /* NewQuestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47194E7C29D94DA900671360 /* NewQuestViewController.swift */; };
-		471FCFDD2A2268B40061CF44 /* Secret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471FCFDC2A2268B40061CF44 /* Secret.swift */; };
 		473B739429CEDC0F00B33C77 /* MyResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473B739329CEDC0F00B33C77 /* MyResultViewController.swift */; };
 		473B739629CEDCBE00B33C77 /* MyResultTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473B739529CEDCBE00B33C77 /* MyResultTableViewCell.swift */; };
 		473B739829CEE3CC00B33C77 /* MyResultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473B739729CEE3CC00B33C77 /* MyResultViewModel.swift */; };
@@ -52,6 +51,9 @@
 		47CC89602A46844F0020246E /* PointerHttpRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CC895F2A46844F0020246E /* PointerHttpRouter.swift */; };
 		47CC89622A46BF110020246E /* RoomAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CC89612A46BF110020246E /* RoomAPI.swift */; };
 		47CC896A2A4EDD0B0020246E /* AppleUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CC89692A4EDD0B0020246E /* AppleUser.swift */; };
+		47CC896F2A4EF51D0020246E /* Secret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CC896E2A4EF51D0020246E /* Secret.swift */; };
+		47CC89712A5015E10020246E /* CreateUserIDViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CC89702A5015E10020246E /* CreateUserIDViewController.swift */; };
+		47CC89732A5016D40020246E /* CreateUserIDViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CC89722A5016D40020246E /* CreateUserIDViewModel.swift */; };
 		CD06677E2A04E8870003C7B4 /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0667792A04E8870003C7B4 /* ProfileViewModel.swift */; };
 		CD06677F2A04E8870003C7B4 /* ProfileInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD06677B2A04E8870003C7B4 /* ProfileInfoView.swift */; };
 		CD0667802A04E8870003C7B4 /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD06677C2A04E8870003C7B4 /* ProfileViewController.swift */; };
@@ -121,7 +123,6 @@
 		47117CE329CD92C9001707C8 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		47117CE529CD92D5001707C8 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		47194E7C29D94DA900671360 /* NewQuestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewQuestViewController.swift; sourceTree = "<group>"; };
-		471FCFDC2A2268B40061CF44 /* Secret.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secret.swift; sourceTree = "<group>"; };
 		473B739329CEDC0F00B33C77 /* MyResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyResultViewController.swift; sourceTree = "<group>"; };
 		473B739529CEDCBE00B33C77 /* MyResultTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyResultTableViewCell.swift; sourceTree = "<group>"; };
 		473B739729CEE3CC00B33C77 /* MyResultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyResultViewModel.swift; sourceTree = "<group>"; };
@@ -153,6 +154,9 @@
 		47CC89612A46BF110020246E /* RoomAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomAPI.swift; sourceTree = "<group>"; };
 		47CC89672A4ED46E0020246E /* Pointer_iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Pointer_iOS.entitlements; sourceTree = "<group>"; };
 		47CC89692A4EDD0B0020246E /* AppleUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleUser.swift; sourceTree = "<group>"; };
+		47CC896E2A4EF51D0020246E /* Secret.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secret.swift; sourceTree = "<group>"; };
+		47CC89702A5015E10020246E /* CreateUserIDViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateUserIDViewController.swift; sourceTree = "<group>"; };
+		47CC89722A5016D40020246E /* CreateUserIDViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateUserIDViewModel.swift; sourceTree = "<group>"; };
 		CD0667792A04E8870003C7B4 /* ProfileViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
 		CD06677B2A04E8870003C7B4 /* ProfileInfoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileInfoView.swift; sourceTree = "<group>"; };
 		CD06677C2A04E8870003C7B4 /* ProfileViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
@@ -279,6 +283,7 @@
 			children = (
 				47117CE329CD92C9001707C8 /* LoginViewController.swift */,
 				473B73A229D029A200B33C77 /* TermsViewController.swift */,
+				47CC89702A5015E10020246E /* CreateUserIDViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -288,6 +293,7 @@
 			children = (
 				47117CE529CD92D5001707C8 /* LoginViewModel.swift */,
 				473B73A729D18A1700B33C77 /* TermsViewModel.swift */,
+				47CC89722A5016D40020246E /* CreateUserIDViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -576,7 +582,7 @@
 		CD23208E29B8CFC8003D0B84 /* Secret */ = {
 			isa = PBXGroup;
 			children = (
-				471FCFDC2A2268B40061CF44 /* Secret.swift */,
+				47CC896E2A4EF51D0020246E /* Secret.swift */,
 			);
 			path = Secret;
 			sourceTree = "<group>";
@@ -894,7 +900,6 @@
 				4749D48429BDEECE00011E06 /* RoomViewController.swift in Sources */,
 				CD5BCC5D29F53B8500DD44F7 /* PreferenceViewModel.swift in Sources */,
 				4749D47B29B9BB3300011E06 /* UIImage.swift in Sources */,
-				471FCFDD2A2268B40061CF44 /* Secret.swift in Sources */,
 				47665AD62A1C889D00A95154 /* ChattingRoomViewController.swift in Sources */,
 				CD6BCDAA29BB4B5E00DB024C /* UIBarButtonItem.swift in Sources */,
 				CD5BCC5A29F53B5E00DD44F7 /* PreferenceModel.swift in Sources */,
@@ -902,11 +907,13 @@
 				473B73A129CEF15E00B33C77 /* HintViewController.swift in Sources */,
 				CD23209C29B8D9C1003D0B84 /* BaseTabBarController.swift in Sources */,
 				473B739A29CEE41100B33C77 /* ViewModelType.swift in Sources */,
+				47CC89712A5015E10020246E /* CreateUserIDViewController.swift in Sources */,
 				CD90B48A29BE327700772192 /* PointerAlert.swift in Sources */,
 				CD23209829B8D2FB003D0B84 /* UIColor.swift in Sources */,
 				47CC89622A46BF110020246E /* RoomAPI.swift in Sources */,
 				CD0EE9212A074B8F0090BF48 /* ProfileParentViewController.swift in Sources */,
 				47117CE629CD92D5001707C8 /* LoginViewModel.swift in Sources */,
+				47CC89732A5016D40020246E /* CreateUserIDViewModel.swift in Sources */,
 				CD5BCC5F29F5423700DD44F7 /* PreferenceItemCell.swift in Sources */,
 				4749D48D29C06C7400011E06 /* RoomTopView.swift in Sources */,
 				CD6BCDA629BB2D5B00DB024C /* HomeController.swift in Sources */,
@@ -947,6 +954,7 @@
 				47117C9F29C2F391001707C8 /* RoomModel.swift in Sources */,
 				47117CA729C72EC6001707C8 /* ResultViewModel.swift in Sources */,
 				47CC895E2A4684390020246E /* PointerHttpService.swift in Sources */,
+				47CC896F2A4EF51D0020246E /* Secret.swift in Sources */,
 				4749D48F29C0708000011E06 /* RoomBottomView.swift in Sources */,
 				CD2DBEC629C62BDE005E377C /* AccountInfoCell.swift in Sources */,
 				473B73A329D029A200B33C77 /* TermsViewController.swift in Sources */,

--- a/Pointer_iOS.xcodeproj/project.pbxproj
+++ b/Pointer_iOS.xcodeproj/project.pbxproj
@@ -50,7 +50,6 @@
 		47CC895E2A4684390020246E /* PointerHttpService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CC895D2A4684390020246E /* PointerHttpService.swift */; };
 		47CC89602A46844F0020246E /* PointerHttpRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CC895F2A46844F0020246E /* PointerHttpRouter.swift */; };
 		47CC89622A46BF110020246E /* RoomAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CC89612A46BF110020246E /* RoomAPI.swift */; };
-		47CC896A2A4EDD0B0020246E /* AppleUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CC89692A4EDD0B0020246E /* AppleUser.swift */; };
 		47CC896F2A4EF51D0020246E /* Secret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CC896E2A4EF51D0020246E /* Secret.swift */; };
 		47CC89712A5015E10020246E /* CreateUserIDViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CC89702A5015E10020246E /* CreateUserIDViewController.swift */; };
 		47CC89732A5016D40020246E /* CreateUserIDViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CC89722A5016D40020246E /* CreateUserIDViewModel.swift */; };
@@ -153,7 +152,6 @@
 		47CC895F2A46844F0020246E /* PointerHttpRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointerHttpRouter.swift; sourceTree = "<group>"; };
 		47CC89612A46BF110020246E /* RoomAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomAPI.swift; sourceTree = "<group>"; };
 		47CC89672A4ED46E0020246E /* Pointer_iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Pointer_iOS.entitlements; sourceTree = "<group>"; };
-		47CC89692A4EDD0B0020246E /* AppleUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleUser.swift; sourceTree = "<group>"; };
 		47CC896E2A4EF51D0020246E /* Secret.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secret.swift; sourceTree = "<group>"; };
 		47CC89702A5015E10020246E /* CreateUserIDViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateUserIDViewController.swift; sourceTree = "<group>"; };
 		47CC89722A5016D40020246E /* CreateUserIDViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateUserIDViewModel.swift; sourceTree = "<group>"; };
@@ -410,7 +408,6 @@
 		47CC89682A4EDCFC0020246E /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				47CC89692A4EDD0B0020246E /* AppleUser.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -927,7 +924,6 @@
 				CD5BCC6129F546A500DD44F7 /* PreferenceItemHeader.swift in Sources */,
 				CD07E59F29CE1EEE00B52885 /* NotificationViewController.swift in Sources */,
 				47117CB029CB0487001707C8 /* FloatingChatViewController.swift in Sources */,
-				47CC896A2A4EDD0B0020246E /* AppleUser.swift in Sources */,
 				CD2F79BE2A0FC7910094F81F /* FriendsListViewController.swift in Sources */,
 				CD2DBEC229C62234005E377C /* SearchResultController.swift in Sources */,
 				473B73A829D18A1700B33C77 /* TermsViewModel.swift in Sources */,

--- a/Pointer_iOS/API/Login/LoginDataManger.swift
+++ b/Pointer_iOS/API/Login/LoginDataManger.swift
@@ -27,20 +27,22 @@ class LoginDataManager {
     
     static var Headers : HTTPHeaders = ["Content-Type" : "application/json"]
     
-    static func posts(_ parameter: KakaoInput,_ completion: @escaping (KakaoInput, LoginResultType) -> Void){
+    static func posts(_ parameter: AuthInputModel,_ completion: @escaping (AuthResultModel, LoginResultType) -> Void){
+        print("Login URL = \(Secret.loginURL)")
+        
         AF.request(Secret.loginURL, method: .post, parameters: parameter, encoder: JSONParameterEncoder.default, headers: Headers)
             .validate(statusCode: 200..<500)
-            .responseDecodable(of: KakaoModel.self) { response in
+            .responseDecodable(of: AuthResultModel.self) { response in
             switch response.result {
             case .success(let result):
                 print("카카오 데이터 전송 성공")
                 print(result)
                 switch(result.code){
                 case "A000":
-                    completion(parameter, LoginResultType.success)
+                    completion(result, LoginResultType.success)
                     return
                 case "A001":
-                    completion(parameter, LoginResultType.existedUser)
+                    completion(result, LoginResultType.existedUser)
                     return
                 default:
                     print("데이터베이스 오류")
@@ -55,13 +57,19 @@ class LoginDataManager {
     }
 }
 
-struct KakaoInput: Encodable {
-    var accessToken: String
+struct AuthInputModel: Encodable {
+    let accessToken: String
 }
 
-struct KakaoModel: Decodable {
-    var status: Int
-    var code: String
-    var message: String
-    var token: String
+struct AuthResultModel: Decodable {
+    let status: Int?
+    let code: String?
+    let message: String?
+    let token: PointerToken?
+    let userId: Int?
+}
+
+struct PointerToken: Decodable {
+    let accessToken: String?
+    let refreshToken: String?
 }

--- a/Pointer_iOS/API/Login/LoginDataManger.swift
+++ b/Pointer_iOS/API/Login/LoginDataManger.swift
@@ -62,14 +62,14 @@ struct AuthInputModel: Encodable {
 }
 
 struct AuthResultModel: Decodable {
-    let status: Int?
-    let code: String?
-    let message: String?
-    let token: PointerToken?
-    let userId: Int?
+    let status: Int
+    let code: String
+    let message: String
+    let userId: Int
 }
 
+// 이후에
 struct PointerToken: Decodable {
-    let accessToken: String?
-    let refreshToken: String?
+    let accessToken: String
+    let refreshToken: String
 }

--- a/Pointer_iOS/API/Login/LoginDataManger.swift
+++ b/Pointer_iOS/API/Login/LoginDataManger.swift
@@ -68,7 +68,7 @@ struct LoginDataManager {
         }
     }
     
-    func idCheckPost(_ parameter: AuthIdInputModel,_ completion: @escaping (AuthIdResultModel) -> Void) {
+    func idCheckPost(_ parameter: AuthIdInputModel,_ completion: @escaping (AuthIdResultModel, LoginResultType) -> Void) {
         
         print("중복 확인 버튼 함수 시작")
         AF.request(Secret.checkIdURL, method: .post, parameters: parameter, encoder: JSONParameterEncoder.default, headers: Headers)
@@ -79,13 +79,13 @@ struct LoginDataManager {
                 print(result)
                 switch(result.code){
                 case "C004":
-                    completion(result)
+                    completion(result, LoginResultType.doubleCheck)
                     return
                 case "A002":
-                    print("아이디 중복")
+                    completion(result, LoginResultType.duplicatedId)
                     return
                 case "C001":
-                    print("회원 정보 없음")
+                    completion(result, LoginResultType.notFoundId)
                     return
                 default:
                     print("데이터베이스 오류")
@@ -98,7 +98,7 @@ struct LoginDataManager {
         }
     }
     
-    func idSavePost(_ parameter: AuthIdInputModel,_ completion: @escaping (AuthIdResultModel) -> Void) {
+    func idSavePost(_ parameter: AuthIdInputModel,_ completion: @escaping (AuthIdResultModel, LoginResultType) -> Void) {
         print("확인 버튼 함수 시작")
         
         AF.request(Secret.saveIdURL, method: .post, parameters: parameter, encoder: JSONParameterEncoder.default, headers: Headers)
@@ -109,13 +109,13 @@ struct LoginDataManager {
                 print(result)
                 switch(result.code){
                 case "C003":
-                    completion(result)
+                    completion(result, LoginResultType.saveId)
                     return
                 case "C005":
-                    print("아이디 중복 확인 실패")
+                    completion(result, LoginResultType.haveToCheckId)
                     return
                 case "C001":
-                    print("회원 정보 없음")
+                    completion(result, LoginResultType.notFoundId)
                     return
                 default:
                     print("데이터베이스 오류")

--- a/Pointer_iOS/API/RoomAPI.swift
+++ b/Pointer_iOS/API/RoomAPI.swift
@@ -8,5 +8,5 @@
 import RxSwift
 
 protocol RoomAPI {
-    func fetchRooms() -> Single<KakaoModel>
+//    func fetchRooms() -> Single<KakaoModel>
 }

--- a/Pointer_iOS/AppDelegate.swift
+++ b/Pointer_iOS/AppDelegate.swift
@@ -35,8 +35,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         // set current user
         SBUGlobals.currentUser = SBUUser(userId: "userA")
-        
-        
+    
         return true
     }
 

--- a/Pointer_iOS/Base/BaseTabBarController.swift
+++ b/Pointer_iOS/Base/BaseTabBarController.swift
@@ -27,7 +27,7 @@ class BaseTabBarController: UITabBarController {
         let nav1 = templateNavigationController(UIImage(systemName: "message.fill"), title: "메시지", viewController: firstVC)
         
         // 두번째 탭
-        let secondVC = CreateUserIDViewController()
+        let secondVC = LoginViewController()
         let nav2 = templateNavigationController(UIImage(systemName: "house"), title: "홈", viewController: secondVC)
         
         // 세번째 탭

--- a/Pointer_iOS/Base/BaseTabBarController.swift
+++ b/Pointer_iOS/Base/BaseTabBarController.swift
@@ -27,7 +27,7 @@ class BaseTabBarController: UITabBarController {
         let nav1 = templateNavigationController(UIImage(systemName: "message.fill"), title: "메시지", viewController: firstVC)
         
         // 두번째 탭
-        let secondVC = LoginViewController()
+        let secondVC = TermsViewController(viewModel: TermsViewModel(authResultModel: AuthResultModel(status: 404, code: "asd", message: "asd", userId: 3)))
         let nav2 = templateNavigationController(UIImage(systemName: "house"), title: "홈", viewController: secondVC)
         
         // 세번째 탭

--- a/Pointer_iOS/Base/BaseTabBarController.swift
+++ b/Pointer_iOS/Base/BaseTabBarController.swift
@@ -27,7 +27,7 @@ class BaseTabBarController: UITabBarController {
         let nav1 = templateNavigationController(UIImage(systemName: "message.fill"), title: "메시지", viewController: firstVC)
         
         // 두번째 탭
-        let secondVC = LoginViewController()
+        let secondVC = CreateUserIDViewController()
         let nav2 = templateNavigationController(UIImage(systemName: "house"), title: "홈", viewController: secondVC)
         
         // 세번째 탭

--- a/Pointer_iOS/Base/BaseTabBarController.swift
+++ b/Pointer_iOS/Base/BaseTabBarController.swift
@@ -27,7 +27,7 @@ class BaseTabBarController: UITabBarController {
         let nav1 = templateNavigationController(UIImage(systemName: "message.fill"), title: "메시지", viewController: firstVC)
         
         // 두번째 탭
-        let secondVC = TermsViewController(viewModel: TermsViewModel(authResultModel: AuthResultModel(status: 404, code: "asd", message: "asd", userId: 3)))
+        let secondVC = LoginViewController()
         let nav2 = templateNavigationController(UIImage(systemName: "house"), title: "홈", viewController: secondVC)
         
         // 세번째 탭

--- a/Pointer_iOS/Info.plist
+++ b/Pointer_iOS/Info.plist
@@ -2,14 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>사진 및 동영상 추가를 위한 앨범 사용 권한</string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>동영상 촬영 및 음성인식을 위한 권한 필요</string>
-	<key>NSCameraUsageDescription</key>
-	<string>사진 및 동영상 첨부를 위한 카메라 사용 권한</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>사진 및 동영상 첨부를 위한 앨범 사용 권한</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Pointer_iOS/SceneDelegate.swift
+++ b/Pointer_iOS/SceneDelegate.swift
@@ -14,13 +14,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
         window?.rootViewController = BaseTabBarController()
         window?.makeKeyAndVisible()
+        window?.overrideUserInterfaceStyle = .dark // 다크모드 고정
     }
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {

--- a/Pointer_iOS/Sources/LoginScene/View/CreateUserIDViewController.swift
+++ b/Pointer_iOS/Sources/LoginScene/View/CreateUserIDViewController.swift
@@ -1,0 +1,38 @@
+//
+//  CreateUserIDViewController.swift
+//  Pointer_iOS
+//
+//  Created by 박현준 on 2023/07/01.
+//
+
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+
+class CreateUserIDViewController: BaseViewController {
+
+//MARK: - Properties
+    
+    
+    
+    
+//MARK: - set UI
+    func setUI() {
+        
+    }
+    
+    func setUIConstraints() {
+        
+    }
+    
+    
+    
+    
+//MARK: - Life Cycles
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUI()
+        setUIConstraints()
+    }
+}

--- a/Pointer_iOS/Sources/LoginScene/View/CreateUserIDViewController.swift
+++ b/Pointer_iOS/Sources/LoginScene/View/CreateUserIDViewController.swift
@@ -13,12 +13,21 @@ import RxCocoa
 class CreateUserIDViewController: BaseViewController {
 
     var disposeBag = DisposeBag()
-    lazy var userIdViewModel: CreateUserIDViewModel = { CreateUserIDViewModel() }()
+    let createUserIdViewModel: CreateUserIDViewModel
+    
+    init(viewModel: CreateUserIDViewModel, nibName nibNameOrNil: String? = nil, bundle nibBundleOrNil: Bundle? = nil) {
+        self.createUserIdViewModel = viewModel
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
 //MARK: - RX
     func bindViewModel() {
         let input = CreateUserIDViewModel.Input(idTextFieldEditEvent: inputUserIDTextfeild.rx.text.orEmpty.asObservable(), idDoubleCheckButtonTapEvent: idDoubleCheckButton.rx.tap.asObservable(), nextButtonTapEvent: nextButton.rx.tap.asObservable())
-        let output = userIdViewModel.transform(input: input)
+        let output = createUserIdViewModel.transform(input: input)
         
         output.idTextFieldLimitedString
             .bind(to: self.inputUserIDTextfeild.rx.text)

--- a/Pointer_iOS/Sources/LoginScene/View/CreateUserIDViewController.swift
+++ b/Pointer_iOS/Sources/LoginScene/View/CreateUserIDViewController.swift
@@ -12,21 +12,115 @@ import RxCocoa
 
 class CreateUserIDViewController: BaseViewController {
 
+    var disposeBag = DisposeBag()
+    let viewModel = CreateUserIDViewModel()
+    
+//MARK: - RX
+    func bindViewModel() {
+        
+    }
+    
+    
 //MARK: - Properties
+    let inputUserIDTextfeild: UITextField = {
+        $0.attributedPlaceholder = NSAttributedString(
+            string: "입력하세요.",
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.inactiveGray])
+        $0.font = UIFont.notoSans(font: .notoSansKrMedium, size: 14)
+        $0.backgroundColor = .clear
+        $0.textColor = UIColor.white
+        return $0
+    }(UITextField())
     
+    let textfieldBottomLine: UIView = {
+        $0.backgroundColor = UIColor.inactiveGray
+        return $0
+    }(UIView())
     
+    let idDoubleCheckButton: UIButton = {
+        $0.setTitle("중복확인", for: .normal)
+        $0.setTitleColor(UIColor.pointerRed, for: .normal)
+        $0.titleLabel?.font = UIFont.notoSansBold(size: 14)
+        return $0
+    }(UIButton())
     
+    var checkValueValidLabel: UILabel = {
+        $0.text = "사용가능한 아이디입니다."
+        $0.font = UIFont.notoSansRegular(size: 12)
+        $0.textColor = UIColor.inactiveGray
+        return $0
+    }(UILabel())
+    
+    var checkCountValidLabel: UILabel = {
+        $0.text = "0/30"
+        $0.font = UIFont.notoSansRegular(size: 12)
+        $0.textColor = UIColor.inactiveGray
+        return $0
+    }(UILabel())
+    
+    let noticeValidLabel: UILabel = {
+        $0.text = "・ 영문 숫자 및 특수문자 .과 _만 사용 가능합니다. \n・ 최대 30자까지 가능하며 띄어쓰기를 허용하지 않습니다."
+        $0.font = UIFont.notoSansRegular(size: 12.5)
+        $0.textColor = UIColor.white
+        $0.numberOfLines = 0
+        return $0
+    }(UILabel())
+    
+    var nextButton: UIButton = {
+        $0.backgroundColor = UIColor.rgb(red: 87, green: 90, blue: 107)
+        $0.titleLabel?.font = UIFont.notoSans(font: .notoSansKrMedium, size: 16)
+        $0.titleLabel?.textColor = UIColor.white
+        $0.layer.cornerRadius = 16
+        $0.setTitle("확인", for: .normal)
+        $0.isEnabled = false
+        return $0
+    }(UIButton())
     
 //MARK: - set UI
     func setUI() {
-        
+        view.addSubview(inputUserIDTextfeild)
+        view.addSubview(textfieldBottomLine)
+        view.addSubview(idDoubleCheckButton)
+        view.addSubview(checkValueValidLabel)
+        view.addSubview(checkCountValidLabel)
+        view.addSubview(noticeValidLabel)
+        view.addSubview(nextButton)
     }
     
     func setUIConstraints() {
-        
+        idDoubleCheckButton.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(12)
+            make.trailing.equalToSuperview().inset(17)
+        }
+        inputUserIDTextfeild.snp.makeConstraints { make in
+            make.centerY.equalTo(idDoubleCheckButton.snp.centerY)
+            make.leading.equalToSuperview().inset(17)
+            make.trailing.equalToSuperview().inset(85)
+        }
+        textfieldBottomLine.snp.makeConstraints { make in
+            make.top.equalTo(idDoubleCheckButton.snp.bottom).inset(-7)
+            make.leading.trailing.equalToSuperview().inset(15.5)
+            make.height.equalTo(1)
+        }
+        checkValueValidLabel.snp.makeConstraints { make in
+            make.top.equalTo(textfieldBottomLine.snp.bottom).inset(-7)
+            make.leading.equalToSuperview().inset(17)
+        }
+        checkCountValidLabel.snp.makeConstraints { make in
+            make.top.equalTo(textfieldBottomLine.snp.bottom).inset(-7)
+            make.trailing.equalToSuperview().inset(17)
+        }
+        noticeValidLabel.snp.makeConstraints { make in
+            make.top.equalTo(checkValueValidLabel.snp.bottom).inset(-25)
+            make.leading.equalToSuperview().inset(17)
+        }
+        nextButton.snp.makeConstraints { make in
+            make.bottom.equalToSuperview().inset(33)
+            make.leading.trailing.equalToSuperview().inset(8)
+            make.centerX.equalToSuperview()
+            make.height.equalTo(65)
+        }
     }
-    
-    
     
     
 //MARK: - Life Cycles
@@ -34,5 +128,6 @@ class CreateUserIDViewController: BaseViewController {
         super.viewDidLoad()
         setUI()
         setUIConstraints()
+        bindViewModel()
     }
 }

--- a/Pointer_iOS/Sources/LoginScene/View/CreateUserIDViewController.swift
+++ b/Pointer_iOS/Sources/LoginScene/View/CreateUserIDViewController.swift
@@ -103,7 +103,6 @@ class CreateUserIDViewController: BaseViewController {
         $0.titleLabel?.textColor = UIColor.white
         $0.layer.cornerRadius = 16
         $0.setTitle("확인", for: .normal)
-        $0.isEnabled = false
         return $0
     }(UIButton())
     

--- a/Pointer_iOS/Sources/LoginScene/View/CreateUserIDViewController.swift
+++ b/Pointer_iOS/Sources/LoginScene/View/CreateUserIDViewController.swift
@@ -51,8 +51,21 @@ class CreateUserIDViewController: BaseViewController {
                     self?.checkValueValidLabel.text = "형식에 어긋난 아이디입니다."
                     self?.checkValueValidLabel.textColor = UIColor.pointerRed
                 }
-            }).disposed(by: disposeBag)
-        
+            })
+            .disposed(by: disposeBag)
+     
+        output.nextButtonValid
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] b in
+                if b {
+                    self?.nextButton.isEnabled = true
+                    self?.nextButton.backgroundColor = UIColor.pointerRed
+                } else {
+                    self?.nextButton.isEnabled = false
+                    self?.nextButton.backgroundColor = UIColor.rgb(red: 87, green: 90, blue: 107)
+                }
+            })
+            .disposed(by: disposeBag)
     }
     
     
@@ -101,7 +114,6 @@ class CreateUserIDViewController: BaseViewController {
     }(UILabel())
     
     var nextButton: UIButton = {
-        $0.backgroundColor = UIColor.rgb(red: 87, green: 90, blue: 107)
         $0.titleLabel?.font = UIFont.notoSans(font: .notoSansKrMedium, size: 16)
         $0.titleLabel?.textColor = UIColor.white
         $0.layer.cornerRadius = 16

--- a/Pointer_iOS/Sources/LoginScene/View/CreateUserIDViewController.swift
+++ b/Pointer_iOS/Sources/LoginScene/View/CreateUserIDViewController.swift
@@ -41,9 +41,13 @@ class CreateUserIDViewController: BaseViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] b in
                 if b {
+                    self?.idDoubleCheckButton.isEnabled = true
+                    self?.idDoubleCheckButton.setTitleColor(UIColor.pointerRed, for: .normal)
                     self?.checkValueValidLabel.text = "중복 확인해주세요."
                     self?.checkValueValidLabel.textColor = UIColor.inactiveGray
                 } else {
+                    self?.idDoubleCheckButton.isEnabled = false
+                    self?.idDoubleCheckButton.setTitleColor(UIColor.inactiveGray, for: .normal)
                     self?.checkValueValidLabel.text = "형식에 어긋난 아이디입니다."
                     self?.checkValueValidLabel.textColor = UIColor.pointerRed
                 }
@@ -70,13 +74,12 @@ class CreateUserIDViewController: BaseViewController {
     
     let idDoubleCheckButton: UIButton = {
         $0.setTitle("중복확인", for: .normal)
-        $0.setTitleColor(UIColor.pointerRed, for: .normal)
+        $0.isEnabled = false
         $0.titleLabel?.font = UIFont.notoSansBold(size: 14)
         return $0
     }(UIButton())
     
     var checkValueValidLabel: UILabel = {
-        $0.text = "사용가능한 아이디입니다."
         $0.font = UIFont.notoSansRegular(size: 12)
         $0.textColor = UIColor.inactiveGray
         return $0

--- a/Pointer_iOS/Sources/LoginScene/View/LoginViewController.swift
+++ b/Pointer_iOS/Sources/LoginScene/View/LoginViewController.swift
@@ -23,17 +23,10 @@ class LoginViewController: BaseViewController {
         let input = LoginViewModel.Input(kakaoLoginTap: kakaoButton.rx.tap.asObservable(), appleLoginTap: appleButton.rx.tap.asObservable())
         let output = loginViewModel.transform(input: input)
         
-        output.kakaoLogin
+        output.nextViewController
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] viewController in
                 self?.navigationController?.pushViewController(viewController, animated: true)
-            })
-            .disposed(by: disposeBag)
-        
-        output.appleLogin
-            .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { user in
-                print("Apple Login User Data = \(user)")
             })
             .disposed(by: disposeBag)
     }

--- a/Pointer_iOS/Sources/LoginScene/View/LoginViewController.swift
+++ b/Pointer_iOS/Sources/LoginScene/View/LoginViewController.swift
@@ -27,15 +27,15 @@ class LoginViewController: BaseViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] viewController in
                 self?.navigationController?.pushViewController(viewController, animated: true)
-            }
-            ).disposed(by: disposeBag)
+            })
+            .disposed(by: disposeBag)
         
         output.appleLogin
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { user in
                 print("Apple Login User Data = \(user)")
-            }
-            ).disposed(by: disposeBag)
+            })
+            .disposed(by: disposeBag)
     }
     
     

--- a/Pointer_iOS/Sources/LoginScene/View/TermsViewController.swift
+++ b/Pointer_iOS/Sources/LoginScene/View/TermsViewController.swift
@@ -13,8 +13,17 @@ import RxCocoa
 class TermsViewController: BaseViewController {
 
     var disposeBag = DisposeBag()
-    var viewModel = TermsViewModel()
-
+    let viewModel: TermsViewModel
+    
+    init(viewModel: TermsViewModel) {
+        self.viewModel = viewModel
+        super.init()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
 //MARK: - RX
     func bindViewModel() {
         let input = TermsViewModel.Input(allAllowTapEvent: checkBoxAll.rx.tap.asObservable(), overAgeAllowTapEvent: checkBox1.rx.tap.asObservable(), serviceAllowTapEvent: checkBox2.rx.tap.asObservable(), privateInfoAllowTapEvent: checkBox3.rx.tap.asObservable(), marketingInfoAllowTapEvent: checkBox4.rx.tap.asObservable(), nextButtonTapEvent: nextButton.rx.tap.asObservable())
@@ -124,7 +133,8 @@ class TermsViewController: BaseViewController {
         output.nextButtonTap
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] in
-                
+                let vc = CreateUserIDViewController()
+                self?.navigationController?.pushViewController(vc, animated: true)
             })
             .disposed(by: disposeBag)
     }
@@ -132,6 +142,7 @@ class TermsViewController: BaseViewController {
 //MARK: - UIComponents
     private let serviceLabel: UILabel = {
         $0.text = "서비스 이용동의"
+        $0.textColor = .white
         $0.font = UIFont.notoSansBold(size: 20)
         return $0
     }(UILabel())
@@ -144,6 +155,7 @@ class TermsViewController: BaseViewController {
     
     private let TermAllLabel: UILabel = {
         $0.text = "약관 전체동의"
+        $0.textColor = .white
         $0.font = UIFont.notoSansBold(size: 16)
         return $0
     }(UILabel())
@@ -156,6 +168,7 @@ class TermsViewController: BaseViewController {
     
     private let Label1: UILabel = {
         $0.text = "만 14세 이상입니다."
+        $0.textColor = .white
         $0.font = UIFont.notoSans(font: .notoSansKrMedium, size: 16)
         return $0
     }(UILabel())
@@ -169,6 +182,7 @@ class TermsViewController: BaseViewController {
     
     private let Label2: UILabel = {
         $0.text = "(필수) 서비스 이용 약관"
+        $0.textColor = .white
         $0.font = UIFont.notoSans(font: .notoSansKrMedium, size: 16)
         return $0
     }(UILabel())
@@ -187,6 +201,7 @@ class TermsViewController: BaseViewController {
     
     private let Label3: UILabel = {
         $0.text = "(필수) 개인정보 처리방침"
+        $0.textColor = .white
         $0.font = UIFont.notoSans(font: .notoSansKrMedium, size: 16)
         return $0
     }(UILabel())
@@ -205,6 +220,7 @@ class TermsViewController: BaseViewController {
     
     private let Label4: UILabel = {
         $0.text = "(선택) 마케팅 정보 수신동의"
+        $0.textColor = .white
         $0.font = UIFont.notoSans(font: .notoSansKrMedium, size: 16)
         return $0
     }(UILabel())

--- a/Pointer_iOS/Sources/LoginScene/View/TermsViewController.swift
+++ b/Pointer_iOS/Sources/LoginScene/View/TermsViewController.swift
@@ -15,9 +15,9 @@ class TermsViewController: BaseViewController {
     var disposeBag = DisposeBag()
     let viewModel: TermsViewModel
     
-    init(viewModel: TermsViewModel) {
+    init(viewModel: TermsViewModel, nibName nibNameOrNil: String? = nil, bundle nibBundleOrNil: Bundle? = nil) {
         self.viewModel = viewModel
-        super.init()
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     }
     
     required init?(coder: NSCoder) {
@@ -43,8 +43,8 @@ class TermsViewController: BaseViewController {
         
         output.allAllowButtonValid
             .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] _ in
-                if self?.checkBoxAll.isSelected == true {
+            .subscribe(onNext: { [weak self] b in
+                if b {
                     self?.checkBox1.isSelected = true
                     self?.checkBox2.isSelected = true
                     self?.checkBox3.isSelected = true
@@ -132,9 +132,8 @@ class TermsViewController: BaseViewController {
         
         output.nextButtonTap
             .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] in
-                let vc = CreateUserIDViewController()
-                self?.navigationController?.pushViewController(vc, animated: true)
+            .subscribe(onNext: { [weak self] viewController in
+                self?.navigationController?.pushViewController(viewController, animated: true)
             })
             .disposed(by: disposeBag)
     }

--- a/Pointer_iOS/Sources/LoginScene/ViewModel/CreateUserIDViewModel.swift
+++ b/Pointer_iOS/Sources/LoginScene/ViewModel/CreateUserIDViewModel.swift
@@ -1,0 +1,35 @@
+//
+//  CreateUserIDViewModel.swift
+//  Pointer_iOS
+//
+//  Created by 박현준 on 2023/07/01.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+class CreateUserIDViewModel: ViewModelType {
+    
+//MARK: - Properties
+    var disposeBag = DisposeBag()
+    
+//MARK: - In/Out
+    struct Input {
+        
+    }
+    
+    struct Output {
+        
+    }
+//MARK: - Rxswift Transform
+    func transform(input: Input) -> Output {
+        let output = Output()
+        
+        
+        
+        
+        return output
+    }
+    
+}

--- a/Pointer_iOS/Sources/LoginScene/ViewModel/CreateUserIDViewModel.swift
+++ b/Pointer_iOS/Sources/LoginScene/ViewModel/CreateUserIDViewModel.swift
@@ -16,20 +16,61 @@ class CreateUserIDViewModel: ViewModelType {
     
 //MARK: - In/Out
     struct Input {
-        
+        let idTextFieldEditEvent: Observable<String>
+        let idDoubleCheckButtonTapEvent: Observable<Void>
+        let nextButtonTapEvent: Observable<Void>
     }
     
     struct Output {
-        
+        var idTextFieldCountString = BehaviorRelay<String>(value: "0/20")
+        var idTextFieldLimitedString = PublishRelay<String>()
+        var idTextFieldValidString = BehaviorRelay<Bool>(value: false)
+        var nextButtonValid = BehaviorRelay<Bool>(value: false)
     }
+    
 //MARK: - Rxswift Transform
     func transform(input: Input) -> Output {
         let output = Output()
         
-        
-        
+        input.idTextFieldEditEvent
+            .subscribe { [weak self] text in
+                if let text = text.element,
+                   let self = self {
+                    /// 글자수 30자 제한
+                    let limitedString = self.hintTextFieldLimitedString(text: text)
+                    output.idTextFieldLimitedString.accept(limitedString)
+                    
+                    /// 제한된 글자수 카운트
+                    let textCountString = "\(limitedString.count)/30"
+                    output.idTextFieldCountString.accept(textCountString)
+                    
+                    /// 정규표현식 제한
+                    let validString = self.isValidInputString(limitedString)
+                    output.idTextFieldValidString.accept(validString)
+                }
+            }
+            .disposed(by: disposeBag)
         
         return output
     }
     
+//MARK: - Helper Function
+    
+    // idTextField 글자 수 제한 함수
+    func hintTextFieldLimitedString(text: String) -> String {
+        if text.count > 30 {
+            return String(text.prefix(30))
+        } else {
+            return text
+        }
+    }
+    
+    // idTextField 정규표현식 제한 - 영문, 숫자 및 특수문자 . 과 _
+    func isValidInputString(_ input: String) -> Bool {
+        let pattern = "^[a-zA-Z0-9._]+$"
+        let regex = try! NSRegularExpression(pattern: pattern)
+        let range = NSRange(location: 0, length: input.utf16.count)
+        let matches = regex.matches(in: input, range: range)
+        return !matches.isEmpty
+    }
 }

--- a/Pointer_iOS/Sources/LoginScene/ViewModel/CreateUserIDViewModel.swift
+++ b/Pointer_iOS/Sources/LoginScene/ViewModel/CreateUserIDViewModel.swift
@@ -12,8 +12,14 @@ import RxCocoa
 class CreateUserIDViewModel: ViewModelType {
     
 //MARK: - Properties
-    var disposeBag = DisposeBag()
     
+    var disposeBag = DisposeBag()
+    let authResultModel: AuthResultModel
+    
+    init(authResultModel: AuthResultModel) {
+        self.authResultModel = authResultModel
+    }
+
 //MARK: - In/Out
     struct Input {
         let idTextFieldEditEvent: Observable<String>

--- a/Pointer_iOS/Sources/LoginScene/ViewModel/CreateUserIDViewModel.swift
+++ b/Pointer_iOS/Sources/LoginScene/ViewModel/CreateUserIDViewModel.swift
@@ -59,28 +59,33 @@ class CreateUserIDViewModel: ViewModelType {
         
         input.idDoubleCheckButtonTapEvent
             .withLatestFrom(output.idTextFieldLimitedString)
-            .subscribe { [weak self] text in
+            .subscribe(onNext: { [weak self] text in
                 print("중복 확인 버튼 TAP - \(text)")
                 if let self = self {
                     let authIdInput = AuthIdInputModel(userId: self.authResultModel.userId, id: text)
-                    LoginDataManager.shared.idSavePost(authIdInput) { authIdResultModel in
-                        print(authIdResultModel.message)
+                    LoginDataManager.shared.idSavePost(authIdInput) { authIdResultModel, loginResultType in
+                        if loginResultType == LoginResultType.doubleCheck {
+                            // 중복 확인 성공 시 버튼 Enable
+                            output.nextButtonValid.accept(true)
+                        }
                     }
                 }
-            }
+            })
             .disposed(by: disposeBag)
         
         input.nextButtonTapEvent
             .withLatestFrom(output.idTextFieldLimitedString)
-            .subscribe { [weak self] text in
-                print("확인 버튼 TAP - \(text)")
+            .subscribe(onNext: { [weak self] text in
+                print("중복 확인 버튼 TAP - \(text)")
                 if let self = self {
                     let authIdInput = AuthIdInputModel(userId: self.authResultModel.userId, id: text)
-                    LoginDataManager.shared.idSavePost(authIdInput) { authIdResultModel in
-                        print(authIdResultModel.message)
+                    LoginDataManager.shared.idSavePost(authIdInput) { authIdResultModel, loginResultType in
+                        if loginResultType == LoginResultType.saveId {
+                            // MARK: [FIXME] saveId가 된 후 처리 내용  
+                        }
                     }
                 }
-            }
+            })
             .disposed(by: disposeBag)
         
         return output

--- a/Pointer_iOS/Sources/LoginScene/ViewModel/CreateUserIDViewModel.swift
+++ b/Pointer_iOS/Sources/LoginScene/ViewModel/CreateUserIDViewModel.swift
@@ -57,6 +57,32 @@ class CreateUserIDViewModel: ViewModelType {
             }
             .disposed(by: disposeBag)
         
+        input.idDoubleCheckButtonTapEvent
+            .withLatestFrom(output.idTextFieldLimitedString)
+            .subscribe { [weak self] text in
+                print("중복 확인 버튼 TAP - \(text)")
+                if let self = self {
+                    let authIdInput = AuthIdInputModel(userId: self.authResultModel.userId, id: text)
+                    LoginDataManager.shared.idSavePost(authIdInput) { authIdResultModel in
+                        print(authIdResultModel.message)
+                    }
+                }
+            }
+            .disposed(by: disposeBag)
+        
+        input.nextButtonTapEvent
+            .withLatestFrom(output.idTextFieldLimitedString)
+            .subscribe { [weak self] text in
+                print("확인 버튼 TAP - \(text)")
+                if let self = self {
+                    let authIdInput = AuthIdInputModel(userId: self.authResultModel.userId, id: text)
+                    LoginDataManager.shared.idSavePost(authIdInput) { authIdResultModel in
+                        print(authIdResultModel.message)
+                    }
+                }
+            }
+            .disposed(by: disposeBag)
+        
         return output
     }
     

--- a/Pointer_iOS/Sources/LoginScene/ViewModel/LoginViewModel.swift
+++ b/Pointer_iOS/Sources/LoginScene/ViewModel/LoginViewModel.swift
@@ -114,16 +114,11 @@ class LoginViewModel: NSObject, ViewModelType {
                         print(error)
                     }
                     else {
-                        print("user.kakaoAccout = \(String(describing: user?.kakaoAccount))")
-                        
                         // Token & User
                         guard let accessToken = oauthToken?.accessToken else { return }
                         guard let refreshToken = oauthToken?.refreshToken else {return}
                         guard let userNickname = user?.kakaoAccount?.profile?.nickname else { return }
-                        print("access Token 정보입니다 !!!!!!!!!\(String(describing: accessToken))")
-                        print("refresh Token 정보입니다 @@@@@@@@@@@@@@\(String(describing: refreshToken))")
-                        print("Web으로 로그인")
-                        print("userNickname = \(String(describing: userNickname))")
+                        print("Web으로 로그인 ")
                         
                         let kakaoData = AuthInputModel(accessToken: accessToken)
                         LoginDataManager.posts(kakaoData) { model, loginResultType in
@@ -151,16 +146,11 @@ class LoginViewModel: NSObject, ViewModelType {
                         print(error)
                     }
                     else {
-                        print("user.kakaoAccout = \(String(describing: user?.kakaoAccount))")
-                        
                         // Token & User
                         guard let accessToken = oauthToken?.accessToken else { return }
                         guard let refreshToken = oauthToken?.refreshToken else {return}
                         guard let userNickname = user?.kakaoAccount?.profile?.nickname else { return }
-                        print("access Token 정보입니다 !!!!!!!!!\(String(describing: accessToken))")
-                        print("refresh Token 정보입니다 @@@@@@@@@@@@@@\(String(describing: refreshToken))")
-                        print("Web으로 로그인")
-                        print("userNickname = \(String(describing: userNickname))")
+                        print("App으로 로그인")
                         
                         let kakaoData = AuthInputModel(accessToken: accessToken)
                         LoginDataManager.posts(kakaoData) { model, loginResultType in

--- a/Pointer_iOS/Sources/LoginScene/ViewModel/LoginViewModel.swift
+++ b/Pointer_iOS/Sources/LoginScene/ViewModel/LoginViewModel.swift
@@ -15,10 +15,12 @@ import RxCocoa
 
 class LoginViewModel: NSObject, ViewModelType {
     
+//MARK: - Properties
     var disposeBag = DisposeBag()
     var appleLoginUser = PublishRelay<AppleUser>()
     var kakaoLoginView = PublishRelay<UIViewController>()
     
+//MARK: - In/Out
     struct Input {
         let kakaoLoginTap: Observable<Void>
         let appleLoginTap: Observable<Void>
@@ -28,7 +30,7 @@ class LoginViewModel: NSObject, ViewModelType {
         var kakaoLogin = PublishRelay<UIViewController>()
         var appleLogin = PublishRelay<AppleUser>()
     }
-    
+//MARK: - Rxswift Transform
     func transform(input: Input) -> Output {
         let output = Output()
         
@@ -82,9 +84,8 @@ class LoginViewModel: NSObject, ViewModelType {
         
         let controller = ASAuthorizationController(authorizationRequests: [request])
         controller.delegate = self
-//        controller.presentationContextProvider = self
+        controller.presentationContextProvider = self as? ASAuthorizationControllerPresentationContextProviding
         controller.performRequests()
-        
         
     }
     
@@ -187,37 +188,32 @@ class LoginViewModel: NSObject, ViewModelType {
 //        }
 //    }
 
-
+//MARK: - Apple
 extension LoginViewModel: ASAuthorizationControllerDelegate {
     // 애플 로그인 성공
-        func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
-            if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
-                let userIdentifier = appleIDCredential.user
-                let familyName = appleIDCredential.fullName?.familyName
-                let givenName = appleIDCredential.fullName?.givenName
-                let email = appleIDCredential.email
-                let state = appleIDCredential.state
-                
-                let user = AppleUser(
-                    userIdentifier: userIdentifier,
-                    familyName: familyName,
-                    givenName: givenName,
-                    email: email
-                )
-                
-                self.appleLoginUser.accept(user)
-            }
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
+            let userIdentifier = appleIDCredential.user
+            let familyName = appleIDCredential.fullName?.familyName
+            let givenName = appleIDCredential.fullName?.givenName
+            let email = appleIDCredential.email
+            let state = appleIDCredential.state
+            
+            let user = AppleUser(
+                userIdentifier: userIdentifier,
+                familyName: familyName,
+                givenName: givenName,
+                email: email
+            )
+            
+            print("DEBUG: AppleLogin Result - \(user)")
+            self.appleLoginUser.accept(user)
         }
-        
-        // 애플 로그인 실패
-        func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-            print("Apple Sign In Error: \(error.localizedDescription)")
-        }
+    }
+    
+    // 애플 로그인 실패
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        print("Apple Sign In Error: \(error.localizedDescription)")
+    }
 }
 
-//extension LoginViewModel: ASAuthorizationControllerPresentationContextProviding {
-//    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-//        <#code#>
-//    }
-//
-//}

--- a/Pointer_iOS/Sources/LoginScene/ViewModel/LoginViewModel.swift
+++ b/Pointer_iOS/Sources/LoginScene/ViewModel/LoginViewModel.swift
@@ -46,6 +46,16 @@ class LoginViewModel: NSObject, ViewModelType {
                             self?.kakaoLoginView.accept(TermsViewController(viewModel: termsViewModel))
                         case .dataBaseError:
                             return
+                        case .doubleCheck:
+                            return
+                        case .duplicatedId:
+                            return
+                        case .saveId:
+                            return
+                        case .haveToCheckId:
+                            return
+                        case .notFoundId:
+                            return
                         }
                     }
                 } else {
@@ -58,6 +68,17 @@ class LoginViewModel: NSObject, ViewModelType {
                             self?.kakaoLoginView.accept(TermsViewController(viewModel: termsViewModel))
                         case .dataBaseError:
                             return
+                        case .doubleCheck:
+                            return
+                        case .duplicatedId:
+                            return
+                        case .saveId:
+                            return
+                        case .haveToCheckId:
+                            return
+                        case .notFoundId:
+                            return
+                        
                         }
                     }
                 }
@@ -121,7 +142,7 @@ class LoginViewModel: NSObject, ViewModelType {
                         print("Web으로 로그인 ")
                         
                         let kakaoData = AuthInputModel(accessToken: accessToken)
-                        LoginDataManager.posts(kakaoData) { model, loginResultType in
+                        LoginDataManager.shared.posts(kakaoData) { model, loginResultType in
                             completion(loginResultType, model)
                         }
                     }
@@ -153,7 +174,7 @@ class LoginViewModel: NSObject, ViewModelType {
                         print("App으로 로그인")
                         
                         let kakaoData = AuthInputModel(accessToken: accessToken)
-                        LoginDataManager.posts(kakaoData) { model, loginResultType in
+                        LoginDataManager.shared.posts(kakaoData) { model, loginResultType in
                             completion(loginResultType, model)
                         }
                     }

--- a/Pointer_iOS/Sources/LoginScene/ViewModel/TermsViewModel.swift
+++ b/Pointer_iOS/Sources/LoginScene/ViewModel/TermsViewModel.swift
@@ -12,12 +12,11 @@ import RxCocoa
 class TermsViewModel: ViewModelType {
     
 //    var loginNickname = ""
-    var loginAccessToken = ""
+    let authResultModel: AuthResultModel
     
     
-    init(loginAccessToken: String = "") {
-        self.loginAccessToken = loginAccessToken
-        print(loginAccessToken)
+    init(authResultModel: AuthResultModel) {
+        self.authResultModel = authResultModel
     }
     
     struct Input {


### PR DESCRIPTION
1. 유저 ID 생성화면 구현
2. LoginView -> TermsView -> CreateUserIDView 화면 이동 시 AuthResultModel이 담긴 ViewModel 의존성 주입해 이동
3. id 중복 확인 구현
4. id 저장 구현
5. TextField에 입력 없을 시 중복 버튼 비활성화
6. 중복 확인 성공 시 확인 버튼 활성화
7. Apple 로그인 후 accessToken을 Kakao 로그인과 같이 서버연동 -> output의 publishRelay 하나의 객체로 교체