### PR TITLE
feat: 로그인 userId -> Token 변경 & Token 재발급 연결 전

### DIFF
--- a/Pointer_iOS/API/Auth/AuthNetworkManager.swift
+++ b/Pointer_iOS/API/Auth/AuthNetworkManager.swift
@@ -117,6 +117,25 @@ struct AuthNetworkManager {
         }
     }
     
+    func reissuePost(_ refreshToken: String, _ completion: @escaping (AuthResultModel) -> Void) {
+        let router = router.reissue(refreshToken)
+        
+        AF.request(router.url,
+                   method: router.method,
+                   headers: router.headers)
+            .validate(statusCode: 200..<500)
+            .responseDecodable(of: AuthResultModel.self) { response in
+            switch response.result {
+            case .success(let result):
+                print("Token 재발급 데이터 전송 성공 - \(result)")
+                completion(result)
+            case .failure(let error):
+                print(error.localizedDescription)
+                print(response.error ?? "")
+            }
+        }
+    }
+    
 }
 
 

--- a/Pointer_iOS/API/Auth/AuthNetworkManager.swift
+++ b/Pointer_iOS/API/Auth/AuthNetworkManager.swift
@@ -39,10 +39,14 @@ struct AuthNetworkManager {
     let router = AuthRouter.self
     
 //MARK: - Function
-    func posts(_ parameter: AuthInputModel,_ completion: @escaping (AuthResultModel, LoginResultType) -> Void){
+    func posts(_ parameter: AuthInputModel, _ completion: @escaping (AuthResultModel, LoginResultType) -> Void){
         print("Login URL = \(AuthRouter.login.url)")
         
-        AF.request(router.login.url, method: router.login.method, parameters: parameter, encoder: JSONParameterEncoder.default, headers: router.login.headers)
+        AF.request(router.login.url,
+                   method: router.login.method,
+                   parameters: parameter,
+                   encoder: JSONParameterEncoder.default,
+                   headers: router.login.headers)
             .validate(statusCode: 200..<500)
             .responseDecodable(of: AuthResultModel.self) { response in
             switch response.result {
@@ -62,15 +66,21 @@ struct AuthNetworkManager {
         }
     }
     
-    func idCheckPost(_ parameter: AuthIdInputModel,_ completion: @escaping (AuthIdResultModel, LoginResultType) -> Void) {
-        
+    func idCheckPost(_ parameter: AuthCheckIdInputModel, _ accessToken: String,
+                     _ completion: @escaping (AuthIdResultModel, LoginResultType) -> Void) {
         print("중복 확인 버튼 함수 시작")
-        AF.request(router.checkId.url, method: router.checkId.method, parameters: parameter, encoder: JSONParameterEncoder.default, headers: router.login.headers)
+        let router = router.checkId(accessToken)
+        
+        AF.request(router.url,
+                   method: router.method,
+                   parameters: parameter,
+                   encoder: JSONParameterEncoder.default,
+                   headers: router.headers)
             .validate(statusCode: 200..<500)
             .responseDecodable(of: AuthIdResultModel.self) { response in
             switch response.result {
             case .success(let result):
-                print(result)
+                print("ID 중복 확인 데이터 전송 성공 - \(result)")
                 // rawValue로 resultType 생성
                 let loginResultType = LoginResultType(rawValue: result.code) ?? .unknownedError
                 // 핸들러로 전송
@@ -82,14 +92,21 @@ struct AuthNetworkManager {
         }
     }
     
-    func idSavePost(_ parameter: AuthIdInputModel,_ completion: @escaping (AuthIdResultModel, LoginResultType) -> Void) {
+    func idSavePost(_ parameter: AuthSaveIdInputModel, _ accessToken: String,
+                    _ completion: @escaping (AuthIdResultModel, LoginResultType) -> Void) {
         print("확인 버튼 함수 시작")
+        let router = router.saveId(accessToken)
         
-        AF.request(router.saveId.url, method: router.saveId.method, parameters: parameter, encoder: JSONParameterEncoder.default, headers: router.login.headers)
+        AF.request(router.url,
+                   method: router.method,
+                   parameters: parameter,
+                   encoder: JSONParameterEncoder.default,
+                   headers: router.headers)
             .validate(statusCode: 200..<500)
             .responseDecodable(of: AuthIdResultModel.self) { response in
             switch response.result {
             case .success(let result):
+                print("ID 저장 데이터 전송 성공 - \(result)")
                 // rawValue로 resultType 생성
                 let loginResultType = LoginResultType(rawValue: result.code) ?? .unknownedError
                 completion(result, loginResultType)
@@ -103,33 +120,36 @@ struct AuthNetworkManager {
 }
 
 
-//MARK: - 로그인 시
+//MARK: - 회원가입 시
 struct AuthInputModel: Encodable {
     let accessToken: String
-}
-
-struct AuthIdInputModel: Encodable {
-    let userId: Int
-    let id: String
 }
 
 struct AuthResultModel: Decodable {
     let status: Int
     let code: String
     let message: String
+    let tokenDto: PointerToken?
+}
+
+struct PointerToken: Decodable {
     let userId: Int
+    let accessToken: String
+    let refreshToken: String
+}
+
+//MARK: - ID 중복 체크, 저장 시
+struct AuthSaveIdInputModel: Encodable {
+    let id: String
+}
+
+struct AuthCheckIdInputModel: Encodable {
+    let userId: Int
+    let id: String
 }
 
 struct AuthIdResultModel: Decodable {
     let status: Int
     let code: String
     let message: String
-    let userId: Int?
 }
-
-// 이후에
-struct PointerToken: Decodable {
-    let accessToken: String
-    let refreshToken: String
-}
-

--- a/Pointer_iOS/API/HTTP/AuthRouter.swift
+++ b/Pointer_iOS/API/HTTP/AuthRouter.swift
@@ -10,8 +10,8 @@ import Alamofire
 
 enum AuthRouter {
     case login
-    case checkId
-    case saveId
+    case checkId(_ accessToken: String)
+    case saveId(_ accessToken: String)
 }
 
 extension AuthRouter: HttpRouter {
@@ -47,7 +47,17 @@ extension AuthRouter: HttpRouter {
     }
     
     var headers: HTTPHeaders? {
-        return ["Content-Type" : "application/json"]
+        switch self {
+        case .login:
+            return ["Content-Type" : "application/json"]
+        case .checkId(let accessToken):
+            return ["Content-Type" : "application/json",
+                    "Authorization" : "Bearer \(accessToken)"]
+        case .saveId(let accessToken):
+            return ["Content-Type" : "application/json",
+                    "Authorization" : "Bearer \(accessToken)"]
+        }
+        
     }
     
     var parameters: Parameters? {

--- a/Pointer_iOS/API/HTTP/AuthRouter.swift
+++ b/Pointer_iOS/API/HTTP/AuthRouter.swift
@@ -12,6 +12,7 @@ enum AuthRouter {
     case login
     case checkId(_ accessToken: String)
     case saveId(_ accessToken: String)
+    case reissue(_ refreshToken: String)
 }
 
 extension AuthRouter: HttpRouter {
@@ -32,6 +33,8 @@ extension AuthRouter: HttpRouter {
             return "/auth/checkId"
         case .saveId:
             return "/auth/id"
+        case .reissue:
+            return "/user/reissue"
         }
     }
     
@@ -42,6 +45,8 @@ extension AuthRouter: HttpRouter {
         case .checkId:
             return .post
         case .saveId:
+            return .post
+        case .reissue:
             return .post
         }
     }
@@ -56,6 +61,9 @@ extension AuthRouter: HttpRouter {
         case .saveId(let accessToken):
             return ["Content-Type" : "application/json",
                     "Authorization" : "Bearer \(accessToken)"]
+        case .reissue(let refreshToken):
+            return ["Content-Type" : "application/json",
+                    "Authorization" : "Bearer \(refreshToken)"]
         }
         
     }

--- a/Pointer_iOS/Base/BaseTabBarController.swift
+++ b/Pointer_iOS/Base/BaseTabBarController.swift
@@ -14,7 +14,9 @@ class BaseTabBarController: UITabBarController {
     //MARK: - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
         configureAuth()
     }
     
@@ -22,7 +24,7 @@ class BaseTabBarController: UITabBarController {
     func configureAuth() {
         print("🔥ConfigureAuth")
         // 유저 토큰이 존재하면
-        if TokenManager.getUserToken() != nil {
+        if TokenManager.getUserAccessToken() != nil {
             // ToDo - 액세스 토큰 유효 검사
             configureViewControllers()
         } else {
@@ -50,7 +52,6 @@ class BaseTabBarController: UITabBarController {
         
         // 두번째 탭
         let secondVC = HomeController()
-//        let secondVC = TermsViewController(viewModel: TermsViewModel(authResultModel: AuthResultModel(status: 200, code: "abc", message: "abc", userId: 705)))
         let nav2 = templateNavigationController(UIImage(systemName: "house"), title: "홈", viewController: secondVC)
         
         // 세번째 탭

--- a/Pointer_iOS/Sources/LoginScene/View/LoginViewController.swift
+++ b/Pointer_iOS/Sources/LoginScene/View/LoginViewController.swift
@@ -20,7 +20,8 @@ class LoginViewController: BaseViewController {
     
 //MARK: - RX
     func bindViewModel() {
-        let input = LoginViewModel.Input(kakaoLoginTap: kakaoButton.rx.tap.asObservable(), appleLoginTap: appleButton.rx.tap.asObservable())
+        let input = LoginViewModel.Input(kakaoLoginTap: kakaoButton.rx.tap.asObservable(),
+                                         appleLoginTap: appleButton.rx.tap.asObservable())
         let output = loginViewModel.transform(input: input)
         
         output.nextViewController
@@ -33,6 +34,14 @@ class LoginViewController: BaseViewController {
                     parentVc.present(nav, animated: true, completion: nil)
                 }
             })
+            .disposed(by: disposeBag)
+    
+        output.dissMiss
+            .observe(on: MainScheduler.instance)
+            .subscribe { [weak self] _ in
+                guard let self = self else { return }
+                self.dismiss(animated: true)
+            }
             .disposed(by: disposeBag)
     }
     

--- a/Pointer_iOS/며소/TokenManager.swift
+++ b/Pointer_iOS/며소/TokenManager.swift
@@ -10,22 +10,40 @@ import Foundation
 struct TokenManager {
     
     // 디바이스에 저장한 토큰을 받아오기
-    static func getUserToken() -> String? {
-        return UserDefaults.standard.string(forKey: "token")
+    static func getUserAccessToken() -> String? {
+        return UserDefaults.standard.string(forKey: "accessToken")
+    }
+    
+    static func getUserRefreshToken() -> String? {
+        return UserDefaults.standard.string(forKey: "refreshToken")
+    }
+    
+    static func getUserId() -> String? {
+        return UserDefaults.standard.string(forKey: "userId")
     }
     
     // 디바이스에 토큰 저장하기
-    static func saveUserToken(token: String) {
-        UserDefaults.standard.set(token, forKey: "token")
+    static func saveUserAccessToken(accessToken: String) {
+        UserDefaults.standard.set(accessToken, forKey: "accessToken")
+    }
+    
+    static func saveUserRefreshToken(refreshToken: String) {
+        UserDefaults.standard.set(refreshToken, forKey: "refreshToken")
+    }
+    
+    static func saveUserId(userId: String) {
+        UserDefaults.standard.set(userId, forKey: "userId")
     }
     
     static func resetUserToken() {
-        UserDefaults.standard.removeObject(forKey: "token")
+        UserDefaults.standard.removeObject(forKey: "accessToken")
+        UserDefaults.standard.removeObject(forKey: "refreshToken")
+        UserDefaults.standard.removeObject(forKey: "userId")
     }
     
     static func getIntUserId() -> Int {
-        if let token = TokenManager.getUserToken() {
-            return Int(token) ?? 0
+        if let id = TokenManager.getUserId() {
+            return Int(id) ?? 0
         } else {
             return 0
         }


### PR DESCRIPTION
로그인 API가 변경됨에 따라 Token으로 변경하였습니다.

1. ID 저장 완료 시 TokenManager를 통해 userId, accessToken, refreshToken을 userDefault에 저장합니다.
2. 회원가입이 되어있는 경우 홈 뷰로 전환 시 생기는 오류 해결하였습니다.
3. Token 재발급 네트워킹 코드와 Router를 만들어 두었습니다.