### PR TITLE
Fix: 1-2 UI & 뒤로 가기 시 룸 재조회 & 1-1 셀에 이름과 ID 바인딩 설정

### DIFF
--- a/Pointer_iOS/Sources/HomeScene/ViewModel/HomeViewModel.swift
+++ b/Pointer_iOS/Sources/HomeScene/ViewModel/HomeViewModel.swift
@@ -47,6 +47,7 @@ class HomeViewModel: ViewModelType {
         // 룸 투표 여부에 따라
         if voted {
             let resultVC = ResultViewController(viewModel: ResultViewModel(roomId, questionId, limitedAt))
+            resultVC.delegate = self
             presenter.accept(resultVC)
         } else {
             let roomVC = RoomViewController(viewModel: RoomViewModel(roomId: roomId))
@@ -175,12 +176,20 @@ class HomeViewModel: ViewModelType {
 //MARK: - RoomViewControllerDelegate
 extension HomeViewModel: RoomViewControllerDelegate {
     // 나가면 룸 조회
-    func didChangedRoomState() {
+    func didChangedRoomStateFromRoomVC() {
         self.requestRoomList()
     }
     
     // 투표 후 결과보기로 이동
     func tapedPoint(viewController: UIViewController) {
         self.presenter.accept(viewController)
+    }
+}
+
+
+//MARK: - ResultViewControllerDelegate
+extension HomeViewModel: ResultViewControllerDelegate {
+    func didChangedRoomStateFromResultVC() {
+        self.requestRoomList()
     }
 }

--- a/Pointer_iOS/Sources/ResultScene/View/ResultView/ResultViewController.swift
+++ b/Pointer_iOS/Sources/ResultScene/View/ResultView/ResultViewController.swift
@@ -12,10 +12,15 @@ import RxCocoa
 import FloatingPanel
 import SendbirdUIKit
 
+protocol ResultViewControllerDelegate: AnyObject {
+    func didChangedRoomStateFromResultVC()
+}
+
 class ResultViewController: BaseViewController {
 //MARK: - properties
     var viewModel: ResultViewModel
     let disposeBag = DisposeBag()
+    weak var delegate: ResultViewControllerDelegate?
     
 //MARK: - Init
     init(viewModel: ResultViewModel) {
@@ -257,5 +262,6 @@ class ResultViewController: BaseViewController {
 //MARK: - Selector
     @objc func backButtonTap() {
         self.navigationController?.dismissWithNavigationPopStyle()
+        self.delegate?.didChangedRoomStateFromResultVC()
     }
 }

--- a/Pointer_iOS/Sources/ResultScene/View/ResultView/ResultViewController.swift
+++ b/Pointer_iOS/Sources/ResultScene/View/ResultView/ResultViewController.swift
@@ -108,17 +108,6 @@ class ResultViewController: BaseViewController {
     }
     
 //MARK: - UIComponents
-    lazy var scrollView: UIScrollView = {
-        $0.backgroundColor = .clear
-        $0.translatesAutoresizingMaskIntoConstraints = false
-        $0.showsVerticalScrollIndicator = true
-        $0.showsHorizontalScrollIndicator = false
-        $0.isScrollEnabled = true
-        $0.contentSize = contentView.bounds.size
-        return $0
-    }(UIScrollView())
-    
-    lazy var contentView = UIView()
     
     lazy var hintText: UILabel = {
         $0.font = UIFont.notoSansRegular(size: 18)
@@ -209,31 +198,20 @@ class ResultViewController: BaseViewController {
     
 //MARK: - Set UI
     func setUI() {
-        view.addSubview(scrollView)
-        scrollView.addSubview(contentView)
-        contentView.addSubview(hintText)
-        contentView.addSubview(peopleStackView)
-        contentView.addSubview(peopleNumStackView)
-        contentView.addSubview(myNameLabel)
-        contentView.addSubview(mySelectedPointLabel)
-        contentView.addSubview(myResultButton)
-        contentView.addSubview(newQuestionTimerLabel)
-        contentView.addSubview(newQuestionButton)
-        contentView.addSubview(kokButton)
+        view.addSubview(hintText)
+        view.addSubview(peopleStackView)
+        view.addSubview(peopleNumStackView)
+        view.addSubview(myNameLabel)
+        view.addSubview(mySelectedPointLabel)
+        view.addSubview(myResultButton)
+        view.addSubview(newQuestionTimerLabel)
+        view.addSubview(newQuestionButton)
+        view.addSubview(kokButton)
     }
     
     func setUIConstraints() {
-        scrollView.snp.makeConstraints { make in
-            make.top.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
-            make.width.equalTo(UIScreen.main.bounds.width)
-        }
-        contentView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
-            make.centerX.equalToSuperview()
-        }
-        
         hintText.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(33)
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(33)
             make.leading.trailing.equalToSuperview().inset(45)
         }
         peopleStackView.snp.makeConstraints { make in
@@ -245,15 +223,15 @@ class ResultViewController: BaseViewController {
             make.trailing.equalToSuperview().inset(55)
         }
         myNameLabel.snp.makeConstraints { make in
-            make.top.equalTo(peopleStackView.snp.bottom).inset(-20)
+            make.top.equalTo(peopleStackView.snp.bottom).inset(-40)
             make.leading.equalToSuperview().inset(53)
         }
         mySelectedPointLabel.snp.makeConstraints { make in
-            make.top.equalTo(peopleNumStackView.snp.bottom).inset(-20)
+            make.top.equalTo(peopleNumStackView.snp.bottom).inset(-40)
             make.trailing.equalToSuperview().inset(55)
         }
         myResultButton.snp.makeConstraints { make in
-            make.top.equalTo(myNameLabel.snp.bottom).inset(-60)
+            make.bottom.equalTo(kokButton.snp.top).inset(-20.8)
             make.leading.equalToSuperview().inset(34.5)
             make.width.equalTo(145)
             make.height.equalTo(44)
@@ -269,11 +247,10 @@ class ResultViewController: BaseViewController {
             make.centerX.equalTo(newQuestionButton.snp.centerX)
         }
         kokButton.snp.makeConstraints { make in
-            make.top.equalTo(myResultButton.snp.bottom).inset(-20)
             make.centerX.equalToSuperview()
             make.leading.trailing.equalToSuperview().inset(34.5)
             make.height.equalTo(50)
-            make.bottom.equalTo(contentView.snp.bottom).inset(15)
+            make.bottom.equalTo(view.safeAreaLayoutGuide).inset(5)
         }
     }
 

--- a/Pointer_iOS/Sources/RoomScene/View/RoomPeopleTableViewCell.swift
+++ b/Pointer_iOS/Sources/RoomScene/View/RoomPeopleTableViewCell.swift
@@ -33,7 +33,6 @@ class RoomPeopleTableViewCell: UITableViewCell {
     }(UIView())
     
     lazy var nameLabel : UILabel = {
-        $0.text = "박현준(devjoonn)"
         $0.font = UIFont.notoSansBold(size: 16)
         $0.textColor = UIColor.black
         $0.textAlignment = .center
@@ -74,6 +73,7 @@ class RoomPeopleTableViewCell: UITableViewCell {
         nameLabel.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.leading.equalToSuperview().inset(15)
+            make.trailing.lessThanOrEqualTo(pointStar.snp.leading).inset(-26)
         }
         
         pointStar.snp.makeConstraints { make in
@@ -86,7 +86,7 @@ class RoomPeopleTableViewCell: UITableViewCell {
     // 선택시 UI 전환
     func configure() {
         guard let user = user else { return }
-        nameLabel.text = "\(user.name)"
+        nameLabel.text = "\(user.name) (\(user.id))"
     }
 
 }

--- a/Pointer_iOS/Sources/RoomScene/View/RoomViewController.swift
+++ b/Pointer_iOS/Sources/RoomScene/View/RoomViewController.swift
@@ -241,6 +241,12 @@ class RoomViewController: BaseViewController {
             let modifyAlert = self.viewModel.getModifyRoomNameAlert(currentRoomName, roomId: roomId)
             self.present(modifyAlert, animated: true)
         }
+        let inviteFriend = PointerAlertActionConfig(title: "친구 초대하기", textColor: .black) { [weak self] _ in
+            let viewModel = FriendsListViewModel(listType: .select, roomId: self?.viewModel.roomId)
+            let viewController = FriendsListViewController(viewModel: viewModel)
+            viewController.delegate = self
+            self?.navigationController?.pushViewController(viewController, animated: true)
+        }
         let report = PointerAlertActionConfig(title: "질문 신고하기", textColor: .red) { [weak self] _ in
             self?.reportTap()
         }
@@ -252,7 +258,7 @@ class RoomViewController: BaseViewController {
         }
 
         let actionSheet = PointerAlert(alertType: .actionSheet,
-                                       configs: [modifyRoomName, report, exitRoom],
+                                       configs: [modifyRoomName, inviteFriend, report, exitRoom],
                                        title: "룸 '\(currentRoomName)'에 대해")
         present(actionSheet, animated: true)
     }
@@ -301,5 +307,12 @@ extension RoomViewController: FloatingPanelControllerDelegate {
         } else {
             fpc.move(to: .full, animated: true)
         }
+    }
+}
+
+//MARK: - FriendsListViewControllerDelegate
+extension RoomViewController: FriendsListViewControllerDelegate {
+    func dismissInviteView() {
+        self.viewModel.searchRoomRequest()
     }
 }

--- a/Pointer_iOS/Sources/RoomScene/View/RoomViewController.swift
+++ b/Pointer_iOS/Sources/RoomScene/View/RoomViewController.swift
@@ -25,7 +25,7 @@ import FloatingPanel
 // 5. 셀을 클릭 시 ViewModel에 배열로 클릭한 셀의 이름들이 저장됨 -> 삭제 시 이름이 똑같다면 문제가 생김(해결[O])
 
 protocol RoomViewControllerDelegate: AnyObject {
-    func didChangedRoomState()
+    func didChangedRoomStateFromRoomVC()
     func tapedPoint(viewController: UIViewController)
 }
 
@@ -164,7 +164,7 @@ class RoomViewController: BaseViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] viewController in
                 self?.navigationController?.popViewController(animated: false)
-                self?.delegate?.didChangedRoomState()
+                self?.delegate?.didChangedRoomStateFromRoomVC()
                 self?.delegate?.tapedPoint(viewController: viewController)
             })
             .disposed(by: disposeBag)
@@ -181,7 +181,7 @@ class RoomViewController: BaseViewController {
             .subscribe { [weak self] b in
                 if b {
                     self?.navigationController?.popViewController(animated: true)
-                    self?.delegate?.didChangedRoomState()
+                    self?.delegate?.didChangedRoomStateFromRoomVC()
                 }
             }
             .disposed(by: disposeBag)
@@ -228,7 +228,7 @@ class RoomViewController: BaseViewController {
 //MARK: - Selector
     @objc func backButtonTap() {
         self.navigationController?.popViewController(animated: true)
-        self.delegate?.didChangedRoomState()
+        self.delegate?.didChangedRoomStateFromRoomVC()
     }
     
     @objc func menuButtonTap() {

--- a/Pointer_iOS/Sources/RoomScene/ViewModel/RoomViewModel.swift
+++ b/Pointer_iOS/Sources/RoomScene/ViewModel/RoomViewModel.swift
@@ -52,7 +52,7 @@ final class RoomViewModel: ViewModelType {
     
     //MARK: - Rxswift Transform
     func transform(input: Input) -> Output {
-        searchRoomRequest(roomId)
+        searchRoomRequest()
         
         /// 0. 상단에서 Output() 및 필요한 저장값들 선언
         let output = Output()
@@ -233,7 +233,9 @@ final class RoomViewModel: ViewModelType {
     }
     
     //MARK: - Network
-    func searchRoomRequest(_ roomId: Int) {
+    func searchRoomRequest() {
+        let roomId = self.roomId
+        
         // 룸 조회 API
         RoomNetworkManager.shared.searchRoomRequest(roomId)
             .subscribe(onNext: { [weak self] result in
@@ -305,6 +307,6 @@ final class RoomViewModel: ViewModelType {
 //MARK: - FriendsListViewControllerDelegate
 extension RoomViewModel: FriendsListViewControllerDelegate {
     func dismissInviteView() {
-        self.searchRoomRequest(self.roomId)
+        self.searchRoomRequest()
     }
 }


### PR DESCRIPTION
1. 1-2에 버튼을 뷰의 하단에 고정하였습니다.
2. 1-2 네비게이션 x 버튼 시 홈의 룸을 재조회 하는 기능을 추가하였습니다.
3. 1-1 룸 인원에 중복된 이름이 있을 시 상황을 고려해 이름 + ID를 추가하였고 이에 맞는 오토레이아웃 설정했습니다.
4. 1-1 룸 내부에서 메뉴 버튼 시 친구초대 시트를 재 추가하였고, 초대 후 1-1로 돌아왔을 시 룸 데이터 재조회 설정하였습니다.