### PR TITLE
Feat: 검색화면 룸 / 계정 연결 & 페이지네이션 & 텍스트필드 색상 변경

### DIFF
--- a/Pointer_iOS/Sources/HomeScene/View/HomeController.swift
+++ b/Pointer_iOS/Sources/HomeScene/View/HomeController.swift
@@ -207,8 +207,11 @@ extension HomeController: RoomPreviewCellDelegate {
             let alert = self.viewModel.getModifyRoomNameAlert(currentName, roomId: roomId)
             self.present(alert, animated: true)
         }
-        let inviteRoomWithLink = PointerAlertActionConfig(title: "링크로 룸 초대", textColor: .black) { _ in
-            print("DEBUG - 링크로 룸 초대 눌림")
+        let inviteRoomWithLink = PointerAlertActionConfig(title: "친구 초대하기", textColor: .black) { [weak self] _ in
+            let viewModel = FriendsListViewModel(listType: .select, roomId: roomId)
+            let viewController = FriendsListViewController(viewModel: viewModel)
+            viewController.delegate = self
+            self?.navigationController?.pushViewController(viewController, animated: true)
         }
         let report = PointerAlertActionConfig(title: "질문 신고하기", textColor: .red) { [weak self] _ in
             self?.reportTap(roomId: roomId, currentName: currentName, questionId: questionId, questionCreatorId: questionCreatorId)
@@ -249,5 +252,12 @@ extension HomeController: RoomPreviewCellDelegate {
         fpc.set(contentViewController: reportVC)
         fpc.track(scrollView: reportVC.scrollView)
         self.present(fpc, animated: true)
+    }
+}
+
+//MARK: - FriendsListViewControllerDelegate
+extension HomeController: FriendsListViewControllerDelegate {
+    func dismissInviteView() {
+        self.viewModel.requestRoomList()
     }
 }

--- a/Pointer_iOS/Sources/HomeScene/ViewModel/HomeViewModel.swift
+++ b/Pointer_iOS/Sources/HomeScene/ViewModel/HomeViewModel.swift
@@ -141,7 +141,7 @@ class HomeViewModel: ViewModelType {
         guard let roomName = changeTo else { return }
         let input = RoomNameChangeInput(privateRoomNm: roomName, roomId: roomId, userId: TokenManager.getIntUserId())
         network.requestRoomNameChange(input: input) { [weak self] response in
-            if response.code == "J000" {
+            if response.code == "P000" {
                 // ToDo - 이녀석을 다시 부르는 방법은 .. ?
                 self?.requestRoomList()
             }

--- a/Pointer_iOS/Sources/RoomScene/ViewModel/RoomViewModel.swift
+++ b/Pointer_iOS/Sources/RoomScene/ViewModel/RoomViewModel.swift
@@ -284,7 +284,7 @@ final class RoomViewModel: ViewModelType {
         guard let roomName = changeTo else { return }
         let input = RoomNameChangeInput(privateRoomNm: roomName, roomId: roomId, userId: TokenManager.getIntUserId())
         HomeNetworkManager.shared.requestRoomNameChange(input: input) { [weak self] response in
-            if response.code == "J000" {
+            if response.code == "P000" {
                 // ToDo - 이녀석을 다시 부르는 방법은 .. ?
                 self?.dismissRoom.accept(true)
             }

--- a/Pointer_iOS/Sources/SearchScene/View/SearchController.swift
+++ b/Pointer_iOS/Sources/SearchScene/View/SearchController.swift
@@ -20,7 +20,7 @@ class SearchController: BaseViewController {
     let searchBar: UITextField = {
         let tf = UITextField()
         tf.translatesAutoresizingMaskIntoConstraints = false
-        tf.backgroundColor = .darkGray
+        tf.backgroundColor = UIColor.navBackColor
         tf.attributedPlaceholder = NSMutableAttributedString(string: "검색어를 입력하세요.", attributes: [NSAttributedString.Key.foregroundColor: UIColor.pointerGray, NSAttributedString.Key.font: UIFont.notoSansRegular(size: 13)])
         tf.textColor = .white
         tf.heightAnchor.constraint(equalToConstant: Device.navigationBarHeight).isActive = true
@@ -92,7 +92,22 @@ class SearchController: BaseViewController {
                 }
             }.disposed(by: disposeBag)
         
+        output.tapedNextViewController
+            .bind { [weak self] viewController in
+                if let vc = viewController {
+                    self?.navigationController?.pushViewController(vc, animated: true)
+                }
+            }
+            .disposed(by: disposeBag)
         
+        viewModel.presenter
+            .bind { [weak self] viewController in
+                if let vc = viewController {
+                    let nav = BaseNavigationController.templateNavigationController(nil, viewController: vc)
+                    self?.tabBarController?.presentWithNavigationPushStyle(nav)
+                }
+            }
+            .disposed(by: disposeBag)
     }
     
     //MARK: - Selector

--- a/Pointer_iOS/Sources/SearchScene/View/SearchResultController.swift
+++ b/Pointer_iOS/Sources/SearchScene/View/SearchResultController.swift
@@ -176,8 +176,12 @@ extension SearchResultController: RoomPreviewCellDelegate {
             let alert = self.viewModel.getModifyRoomNameAlert(currentName, roomId: roomId)
             self.present(alert, animated: true)
         }
-        let inviteRoomWithLink = PointerAlertActionConfig(title: "링크로 룸 초대", textColor: .black) { _ in
-            print("DEBUG - 링크로 룸 초대 눌림")
+        let inviteRoomWithLink = PointerAlertActionConfig(title: "친구 초대하기", textColor: .black) { [weak self] _ in
+            let viewModel = FriendsListViewModel(listType: .select, roomId: roomId)
+            let viewController = FriendsListViewController(viewModel: viewModel)
+            viewController.delegate = self
+            self?.navigationController?.pushViewController(viewController, animated: true)
+
         }
         let report = PointerAlertActionConfig(title: "질문 신고하기", textColor: .red) { [weak self] _ in
             self?.reportTap(roomId: roomId, currentName: currentName, questionId: questionId, questionCreatorId: questionCreatorId)
@@ -218,5 +222,12 @@ extension SearchResultController: RoomPreviewCellDelegate {
         fpc.set(contentViewController: reportVC)
         fpc.track(scrollView: reportVC.scrollView)
         self.present(fpc, animated: true)
+    }
+}
+
+//MARK: - FriendsListViewControllerDelegate
+extension SearchResultController: FriendsListViewControllerDelegate {
+    func dismissInviteView() {
+        self.viewModel.requestRoomList("")
     }
 }

--- a/Pointer_iOS/Sources/SearchScene/View/SearchResultController.swift
+++ b/Pointer_iOS/Sources/SearchScene/View/SearchResultController.swift
@@ -139,20 +139,20 @@ extension SearchResultController: UICollectionViewDelegate, UICollectionViewData
         }
     }
     
-    func scrollViewDidScroll(_ scrollView: UIScrollView) { // scrollView가 스크롤 되었을 때 실행 될 이벤트
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let height = scrollView.frame.height // 스크롤뷰의 전체 높이
         let contentSizeHeight = scrollView.contentSize.height // 전체 콘텐츠 영역의 높이
         let offset = scrollView.contentOffset.y // 클릭 위치
         let reachedBottom = (offset > contentSizeHeight - height) // (클릭 지점 + 스크롤뷰 높이 == 전체 컨텐츠 높이) -> Bool
 
         if resultType == .account {
-            if reachedBottom { // 스크롤이 바닥에 닿았다면 서버에 추가 데이터 요청
+            if reachedBottom { // 스크롤이 바닥에 닿았다면
               scrollViewDidReachBottom(scrollView)
             }
         }
     }
     
-    func scrollViewDidReachBottom(_ scrollView: UIScrollView) { // 서버에 데이터 요청 코드
+    func scrollViewDidReachBottom(_ scrollView: UIScrollView) {
         viewModel.refetchUserResult.accept(())
     }
 }

--- a/Pointer_iOS/Sources/SearchScene/View/SearchResultController.swift
+++ b/Pointer_iOS/Sources/SearchScene/View/SearchResultController.swift
@@ -128,14 +128,11 @@ extension SearchResultController: UICollectionViewDelegate, UICollectionViewData
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         switch resultType {
         case .room:
-            //
-            break
+            let model = roomData[indexPath.row]
+            viewModel.tapedRoomResult.accept(model)
         case .account:
             let model = accountData[indexPath.row]
-            let viewModel = ProfileViewModel(userId: model.userId)
-            let profileVC = ProfileViewController(viewModel: viewModel)
-            
-            self.navigationController?.pushViewController(profileVC, animated: true)
+            viewModel.tapedProfileResult.accept(model)
         }
     }
 }

--- a/Pointer_iOS/Sources/SearchScene/View/SearchResultController.swift
+++ b/Pointer_iOS/Sources/SearchScene/View/SearchResultController.swift
@@ -75,6 +75,8 @@ class SearchResultController: UIViewController {
                 self?.collectionView.reloadData()
             })
             .disposed(by: disposeBag)
+        
+        
     }
     
     //MARK: - Functions
@@ -135,6 +137,23 @@ extension SearchResultController: UICollectionViewDelegate, UICollectionViewData
             let model = accountData[indexPath.row]
             viewModel.tapedProfileResult.accept(model)
         }
+    }
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) { // scrollView가 스크롤 되었을 때 실행 될 이벤트
+        let height = scrollView.frame.height // 스크롤뷰의 전체 높이
+        let contentSizeHeight = scrollView.contentSize.height // 전체 콘텐츠 영역의 높이
+        let offset = scrollView.contentOffset.y // 클릭 위치
+        let reachedBottom = (offset > contentSizeHeight - height) // (클릭 지점 + 스크롤뷰 높이 == 전체 컨텐츠 높이) -> Bool
+
+        if resultType == .account {
+            if reachedBottom { // 스크롤이 바닥에 닿았다면 서버에 추가 데이터 요청
+              scrollViewDidReachBottom(scrollView)
+            }
+        }
+    }
+    
+    func scrollViewDidReachBottom(_ scrollView: UIScrollView) { // 서버에 데이터 요청 코드
+        viewModel.refetchUserResult.accept(())
     }
 }
 

--- a/Pointer_iOS/Sources/SearchScene/View/SearchViewModel.swift
+++ b/Pointer_iOS/Sources/SearchScene/View/SearchViewModel.swift
@@ -79,7 +79,29 @@ final class SearchViewModel: ViewModelType {
     }
     
 //MARK: - Functions
- 
+    // ToDo - 알림 뷰 중복코드 정리
+    func getModifyRoomNameAlert(_ currentName: String, roomId: Int) -> PointerAlert {
+        // 0. 취소 Action
+        let cancelAction = PointerAlertActionConfig(title: "취소", textColor: .black, backgroundColor: .clear, font: .notoSansBold(size: 16), handler: nil)
+        // 1. 확인 Action
+        let confirmAction = PointerAlertActionConfig(title: "완료", textColor: .pointerRed, backgroundColor: .clear, font: .notoSansBold(size: 16)) { [weak self] changeTo in
+            // 2. 입력한 텍스트로 룸 이름 변경 API 호출
+            self?.requestChangeRoomName(changeTo: changeTo, roomId: roomId)
+        }
+        let customView = CustomTextfieldView(roomName: currentName, withViewHeight: 50)
+        let alert = PointerAlert(alertType: .alert, configs: [cancelAction, confirmAction], title: "방 이름 변경", description: "변경할 이름을 입력해주세요", customView: customView)
+        return alert
+    }
+
+    func getExitRoomAlert(roomId: Int) -> PointerAlert {
+        let cancelAction = PointerAlertActionConfig(title: "취소", textColor: .black, backgroundColor: .clear, font: .notoSansRegular(size: 15), handler: nil)
+        let confirmAction = PointerAlertActionConfig(title: "나가기", textColor: .pointerRed, backgroundColor: .clear, font: .notoSansRegular(size: 15)) { [weak self] _ in
+            self?.requestExitRoom(roomId: roomId)
+        }
+        let alert = PointerAlert(alertType: .alert, configs: [cancelAction, confirmAction], title: "룸 나가기", description: "정말로 나가시겠습니까?")
+        return alert
+    }
+    
     
     
 //MARK: - Network
@@ -113,6 +135,32 @@ final class SearchViewModel: ViewModelType {
                 print(model.userList)
                 self.searchAccountResult.accept(model.userList)
                 self.currentPage = model.currentPage
+            }
+        }
+    }
+    
+    // 룸 이름 변경 API
+    func requestChangeRoomName(changeTo: String?, roomId: Int) {
+        guard let roomName = changeTo else { return }
+        let input = RoomNameChangeInput(privateRoomNm: roomName, roomId: roomId, userId: TokenManager.getIntUserId())
+        HomeNetworkManager.shared.requestRoomNameChange(input: input) { [weak self] response in
+            guard let self = self else { return }
+            if response.code == "P000" {
+                // ToDo - 이녀석을 다시 부르는 방법은 .. ?
+                self.requestRoomList(self.lastSearchedKeyword)
+            }
+        }
+    }
+    
+    // 룸 나가기
+    func requestExitRoom(roomId: Int) {
+        HomeNetworkManager.shared.requestExitRoom(roomId: roomId) { [weak self] isSuccessed in
+            guard let self = self else { return }
+            if isSuccessed {
+                self.requestRoomList(self.lastSearchedKeyword)
+                print("성공")
+            } else {
+                print("실패")
             }
         }
     }

--- a/Pointer_iOS/Sources/SearchScene/View/SearchViewModel.swift
+++ b/Pointer_iOS/Sources/SearchScene/View/SearchViewModel.swift
@@ -137,7 +137,7 @@ final class SearchViewModel: ViewModelType {
     }
     
     // 유저 검색
-    func requestAccountList(word: String, lastPage: Int?, completion: (() -> Void)? = nil) {
+    func requestAccountList(word: String, lastPage: Int?) {
         FriendSearchNetworkManager.shared.searchUserListRequest(keyword: word, lastPage: lastPage ?? 0) { [weak self] (model, error) in
             guard let self = self else { return }
             
@@ -185,22 +185,6 @@ final class SearchViewModel: ViewModelType {
             }
         }
     }
-    
-    // 친구 신청, 취소, 수락, 삭제, 거절, 차단, 차단 해제 - 지수님거로 변경 예정
-//    func requestChangingFriendRelation(relation: FriendRelation, memberId: Int) {
-//        FriendNetworkManager.shared.changeFriendRelationRequest(relation: relation, memberId: memberId) { [weak self] (model, error) in
-//            guard let self = self else { return }
-//
-//            if let error = error {
-//                print(error.localizedDescription)
-//                return
-//            }
-//
-//            if let model = model {
-//                print(model)
-//            }
-//        }
-//    }
 }
 
 extension SearchViewModel: ResultViewControllerDelegate {


### PR DESCRIPTION
1. 검색화면에서 룸 이름 수정, 친구 초대, 신고, 룸 나가기, 룸 분기별 이동 처리 했습니다.( 투표 유무에 따라 room으로 이동, result로 이동)
2. 룸 이동 로직이 추가됨에 따라 profile로 이동하는 로직도 수정되었습니다.
3. 텍스트필드 색상이 피그마와 같이 변경되었습니다.
4. 계정 검색의 경우에만 무한스크롤 추가하였습니다. 
유저 검색 response에 유저의 빈 배열이 올 시 lastIndex 값이 true로 변경되어 api 요청을 막도록 하였습니다.