### PR TITLE
fix: 아이디 생성 화면 키보드 처리 & info.plist 권한 Description 설정

### DIFF
--- a/Pointer_iOS.xcodeproj/project.pbxproj
+++ b/Pointer_iOS.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		475B74382A925EFF00C8BB97 /* PointRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475B74372A925EFF00C8BB97 /* PointRouter.swift */; };
 		475B743B2A925FC900C8BB97 /* PointNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475B743A2A925FC900C8BB97 /* PointNetworkManager.swift */; };
 		47665AD62A1C889D00A95154 /* ChattingRoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47665AD52A1C889D00A95154 /* ChattingRoomViewController.swift */; };
+		477A51A02AB87E9000C01E10 /* RxKeyboard in Frameworks */ = {isa = PBXBuildFile; productRef = 477A519F2AB87E9000C01E10 /* RxKeyboard */; };
 		478C9FEF2A5EC295000FA196 /* HomeNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 478C9FEE2A5EC295000FA196 /* HomeNetworkManager.swift */; };
 		478C9FF22A5EDA9E000FA196 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 478C9FF12A5EDA9E000FA196 /* HomeViewModel.swift */; };
 		478C9FF92A603882000FA196 /* RoomNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 478C9FF82A603882000FA196 /* RoomNetworkManager.swift */; };
@@ -328,6 +329,7 @@
 				CD0EE9352A08050B0090BF48 /* RxGesture in Frameworks */,
 				F948AEFF2A860A7400DDC698 /* NVActivityIndicatorView in Frameworks */,
 				47117CF129CD9A1C001707C8 /* KakaoSDK in Frameworks */,
+				477A51A02AB87E9000C01E10 /* RxKeyboard in Frameworks */,
 				CD0EE9302A0804C00090BF48 /* RxRelay in Frameworks */,
 				CDD1DEE029B9FE2600B03973 /* SnapKit in Frameworks */,
 				CD2F79C72A0FD34B0094F81F /* RxDataSources in Frameworks */,
@@ -1146,6 +1148,7 @@
 				F948AEFE2A860A7400DDC698 /* NVActivityIndicatorView */,
 				F948AF002A860A7400DDC698 /* NVActivityIndicatorViewExtended */,
 				F97A64D22A8FC72E0095BECB /* Toast */,
+				477A519F2AB87E9000C01E10 /* RxKeyboard */,
 			);
 			productName = Pointer_iOS;
 			productReference = CD23207629B8C6EB003D0B84 /* Pointer_iOS.app */;
@@ -1188,6 +1191,7 @@
 				F94CD6C02A85169E00A808B9 /* XCRemoteSwiftPackageReference "YPImagePicker" */,
 				F948AEFD2A860A7400DDC698 /* XCRemoteSwiftPackageReference "NVActivityIndicatorView" */,
 				F97A64D12A8FC72E0095BECB /* XCRemoteSwiftPackageReference "Toast-Swift" */,
+				477A519E2AB87E8F00C01E10 /* XCRemoteSwiftPackageReference "RxKeyboard" */,
 			);
 			productRefGroup = CD23207729B8C6EB003D0B84 /* Products */;
 			projectDirPath = "";
@@ -1597,6 +1601,14 @@
 				kind = branch;
 			};
 		};
+		477A519E2AB87E8F00C01E10 /* XCRemoteSwiftPackageReference "RxKeyboard" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/RxSwiftCommunity/RxKeyboard";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
 		CD0EE92C2A0804C00090BF48 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ReactiveX/RxSwift.git";
@@ -1689,6 +1701,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 47117CEF29CD9A1C001707C8 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
 			productName = KakaoSDK;
+		};
+		477A519F2AB87E9000C01E10 /* RxKeyboard */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 477A519E2AB87E8F00C01E10 /* XCRemoteSwiftPackageReference "RxKeyboard" */;
+			productName = RxKeyboard;
 		};
 		CD0EE92D2A0804C00090BF48 /* RxCocoa */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Pointer_iOS.xcodeproj/project.pbxproj
+++ b/Pointer_iOS.xcodeproj/project.pbxproj
@@ -1488,7 +1488,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Pointer_iOS/Pointer_iOS.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 2W8MRY52UN;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Pointer_iOS/Info.plist;
@@ -1497,7 +1497,7 @@
 				INFOPLIST_KEY_NSCameraUsageDescription = "사진 및 동영상 첨부를 위한 카메라 사용 권한";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "동영상 촬영 및 음성인식을 위한 권한 필요";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "사진 및 동영상 추가를 위한 앨범 사용 권한";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "라이브러리에서 사진을 가져오기 위해 권한을 허용합니다.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "프로필 이미지, 배경 이미지 변경을 위해 라이브러리 권한을 허용합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleLightContent;
@@ -1526,7 +1526,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Pointer_iOS/Pointer_iOS.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 2W8MRY52UN;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Pointer_iOS/Info.plist;
@@ -1535,7 +1535,7 @@
 				INFOPLIST_KEY_NSCameraUsageDescription = "사진 및 동영상 첨부를 위한 카메라 사용 권한";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "동영상 촬영 및 음성인식을 위한 권한 필요";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "사진 및 동영상 추가를 위한 앨범 사용 권한";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "라이브러리에서 사진을 가져오기 위해 권한을 허용합니다.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "프로필 이미지, 배경 이미지 변경을 위해 라이브러리 권한을 허용합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleLightContent;

--- a/Pointer_iOS/Info.plist
+++ b/Pointer_iOS/Info.plist
@@ -2,10 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>비디오 사용 권한을 허용합니다.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>카메라 사용 권한을 허용합니다.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>갤러리에서 사진을 가져오기 위해 권한을 허용해주세요.</string>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
+	<string>프로필 이미지, 배경 이미지 변경을 위해 라이브러리 권한을 허용합니다.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -17,6 +19,8 @@
 			</array>
 		</dict>
 	</array>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>kakaokompassauth</string>

--- a/Pointer_iOS/Sources/Common/ValidateIdView/ViewModel/ValidateIdViewModel.swift
+++ b/Pointer_iOS/Sources/Common/ValidateIdView/ViewModel/ValidateIdViewModel.swift
@@ -36,6 +36,7 @@ class ValidateIdViewModel: ViewModelType {
     //MARK: - Public Properties
     public let didSuccessValidation = BehaviorRelay<Bool>(value: false)
     public let userEnteredId: BehaviorRelay<String?>
+    var varUserEnteredId = ""
     
     //MARK: - Rxswift Transform
     func transform(input: Input) -> Output {
@@ -49,6 +50,7 @@ class ValidateIdViewModel: ViewModelType {
                     /// 글자수 30자 제한
                     let limitedString = self.hintTextFieldLimitedString(text: text)
                     self.userEnteredId.accept(limitedString)
+                    self.varUserEnteredId = limitedString
                     
                     /// 제한된 글자수 카운트
                     let textCountString = "\(limitedString.count)/30"
@@ -58,7 +60,10 @@ class ValidateIdViewModel: ViewModelType {
                     let validString = self.isValidInputString(limitedString)
                     output.idTextFieldValidString.accept(validString)
                     
-                    if validString {
+                    if output.duplicatedIdCheck.value && validString {
+                        // 중복 확인 O & 유효성 O
+                        output.validateIdResult.accept(.avaliable)
+                    } else if validString {
                         // 유효성 O
                         output.validateIdResult.accept(.check)
                     } else {
@@ -103,10 +108,12 @@ class ValidateIdViewModel: ViewModelType {
             }
             .disposed(by: disposeBag)
         
-        // 
-        output.idTextFieldCountString
-            .subscribe { _ in
-                output.duplicatedIdCheck.accept(false)
+        //
+        userEnteredId
+            .subscribe { [weak self] text in
+                if text != self?.varUserEnteredId {
+                    output.duplicatedIdCheck.accept(false)
+                }
             }
             .disposed(by: disposeBag)
         

--- a/Pointer_iOS/Sources/LoginScene/View/CreateUserIDViewController.swift
+++ b/Pointer_iOS/Sources/LoginScene/View/CreateUserIDViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 import SnapKit
 import RxSwift
 import RxCocoa
+import RxKeyboard
 
 class CreateUserIDViewController: BaseViewController {
     //MARK: - Properties
@@ -79,13 +80,23 @@ class CreateUserIDViewController: BaseViewController {
                 self?.present(alert, animated: true)
             })
             .disposed(by: disposeBag)
+
+        RxKeyboard.instance.visibleHeight
+            .skip(1)    // 초기 값 버리기
+            .drive(onNext: { [weak self] keyboardVisibleHeight in
+                guard let self = self else { return }
+                self.nextButton.snp.updateConstraints {
+                    $0.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(keyboardVisibleHeight)
+                }
+            })
+            .disposed(by: disposeBag)
     }
     
 //MARK: - set UI
     func setupUI() {
         view.addSubview(nextButton)
         nextButton.snp.makeConstraints { make in
-            make.bottom.equalToSuperview().inset(33)
+            make.bottom.equalTo(view.safeAreaLayoutGuide)
             make.leading.trailing.equalToSuperview().inset(8)
             make.height.equalTo(65)
         }
@@ -110,3 +121,6 @@ class CreateUserIDViewController: BaseViewController {
         self.navigationController?.popViewController(animated: true)
     }
 }
+
+
+

--- a/Pointer_iOS/Sources/LoginScene/View/CreateUserIDViewController.swift
+++ b/Pointer_iOS/Sources/LoginScene/View/CreateUserIDViewController.swift
@@ -15,6 +15,7 @@ class CreateUserIDViewController: BaseViewController {
     //MARK: - Properties
     var disposeBag = DisposeBag()
     let viewModel: CreateUserIDViewModel
+    private let extra = UIApplication.shared.windows.first!.safeAreaInsets.bottom
     private lazy var validateIdView = ValidateIdView(ValidateIdViewModel(authResultModel: viewModel.authResultModel))
     
     private var nextButton: UIButton = {
@@ -85,9 +86,22 @@ class CreateUserIDViewController: BaseViewController {
             .skip(1)    // 초기 값 버리기
             .drive(onNext: { [weak self] keyboardVisibleHeight in
                 guard let self = self else { return }
-                self.nextButton.snp.updateConstraints {
-                    $0.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(keyboardVisibleHeight)
+                // 키보드가 바닥일 때
+                if keyboardVisibleHeight == 0 {
+                    UIView.animate(withDuration: 0) {
+                        self.nextButton.snp.updateConstraints {
+                            $0.bottom.equalTo(self.view.safeAreaLayoutGuide)
+                        }
+                    }
+                // 키보드가 올라왔을 때
+                } else {
+                    UIView.animate(withDuration: 0) {
+                        self.nextButton.snp.updateConstraints {
+                            $0.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(keyboardVisibleHeight - self.extra)
+                        }
+                    }
                 }
+                self.view.layoutIfNeeded()
             })
             .disposed(by: disposeBag)
     }

--- a/Pointer_iOS/Sources/LoginScene/View/TermsViewController.swift
+++ b/Pointer_iOS/Sources/LoginScene/View/TermsViewController.swift
@@ -326,7 +326,7 @@ class TermsViewController: BaseViewController {
             make.centerY.equalTo(Label4.snp.centerY)
         }
         nextButton.snp.makeConstraints { make in
-            make.bottom.equalToSuperview().inset(33)
+            make.bottom.equalTo(view.safeAreaLayoutGuide)
             make.leading.trailing.equalToSuperview().inset(8)
             make.centerX.equalToSuperview()
             make.height.equalTo(65)


### PR DESCRIPTION
**1. 키보드처리** 
- 아이디 생성 화면에서 중복 확인 후 배경을 탭 시 새로 중복해야 했던 오류 수정했습니다.
- 키보드가 올라왔을 시 확인 버튼도 함께 올라오고 내려가게 변경하였습니다.

**2. 앱스토어 리젝에 관련한 info.plist 권한 Description 수정**
- YPImagePicker와 관련하여 카메라, 비디오, 이미지 권한 추가하였고, Target에서 info, buildSetting에 추가로 설정해주었습니다.